### PR TITLE
fix: use containerlab vxlan delete --name to avoid prefix collisions (#252)

### DIFF
--- a/launcher/connectivity/vxlan.go
+++ b/launcher/connectivity/vxlan.go
@@ -172,7 +172,7 @@ func (m *vxlanManager) runContainerlabVxlanToolsDelete(
 	localNodeName,
 	cntLink string,
 ) error {
-	prefix := sanitizeInterfaceName(fmt.Sprintf("vx-%s-%s", localNodeName, cntLink))
+	name := sanitizeInterfaceName(fmt.Sprintf("vx-%s-%s", localNodeName, cntLink))
 
 	cmd := exec.CommandContext( //nolint:gosec
 		ctx,
@@ -180,8 +180,8 @@ func (m *vxlanManager) runContainerlabVxlanToolsDelete(
 		"tools",
 		"vxlan",
 		"delete",
-		"--prefix",
-		prefix,
+		"--name",
+		name,
 	)
 
 	m.logger.Debugf(


### PR DESCRIPTION
## Summary
- Switch `containerlab tools vxlan delete` invocation from `--prefix` to
  `--name` so the deletion is an exact-name match instead of a
  `strings.HasPrefix` match.
- Fixes the bug in #252 where creating a tunnel for link `e1-1` would
  destroy a coexisting `e1-10` tunnel because `vx-<node>-e1-1`
  prefix-matched `vx-<node>-e1-10`.

## Requires
- containerlab with the `--name` flag added in
  srl-labs/containerlab#3167. `CONTAINERLAB_VERSION` in
  `build/launcher.Dockerfile` will need to be bumped to a containerlab
  release that includes that flag.