### PR TITLE
Reusable workflow to build images in parallel with e2e in PRs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -56,13 +56,15 @@ jobs:
           esac
           echo "push=$push" >> "$GITHUB_OUTPUT"
 
-  # prs never push images, so build them alongside e2e purely to prove the builds still work.
+  # prs never push images, so build them alongside e2e purely to prove the builds still work. amd64
+  # alone is enough of a smoke test there -- arm64 builds are much slower and get covered on merge.
   images:
     if: ${{ github.event_name == 'pull_request' }}
     needs: prep
     uses: ./.github/workflows/images.yaml
     with:
       push: false
+      amd64-only: true
       build-version: 0.0.0-${{ needs.prep.outputs.short_sha }}
     secrets: inherit
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -21,13 +21,19 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yaml
 
-  test:
-    uses: ./.github/workflows/test.yaml
+  unit:
+    uses: ./.github/workflows/unit.yaml
 
+  e2e:
+    needs: unit
+    uses: ./.github/workflows/e2e.yaml
+
+  # only computes outputs, so it is deliberately not gated on e2e -- that lets the pr image builds
+  # start alongside e2e while the publishing path below still waits for it.
   prep:
     needs:
       - lint
-      - test
+      - unit
     runs-on: ubuntu-24.04
     outputs:
       push: ${{ steps.ctx.outputs.push }}
@@ -50,8 +56,24 @@ jobs:
           esac
           echo "push=$push" >> "$GITHUB_OUTPUT"
 
+  # prs never push images, so build them alongside e2e purely to prove the builds still work.
   images:
+    if: ${{ github.event_name == 'pull_request' }}
     needs: prep
+    uses: ./.github/workflows/images.yaml
+    with:
+      push: false
+      build-version: 0.0.0-${{ needs.prep.outputs.short_sha }}
+    secrets: inherit
+
+  # everywhere else the images land in ghcr, so they wait for e2e. e2e skips itself when not
+  # on/targeting main (ie a dispatch from a feature branch) and a skipped need would skip this job
+  # too, hence spelling out the needs results instead of relying on the implicit success gate.
+  images-publish:
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.prep.result == 'success' && needs.e2e.result != 'failure' }}
+    needs:
+      - prep
+      - e2e
     uses: ./.github/workflows/images.yaml
     with:
       push: ${{ needs.prep.outputs.push == 'true' }}
@@ -62,7 +84,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     needs:
       - prep
-      - images
+      - images-publish
     runs-on: ubuntu-24.04
     steps:
       - name: checkout
@@ -98,7 +120,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && needs.prep.outputs.push == 'true' }}
     needs:
       - prep
-      - images
+      - images-publish
     runs-on: ubuntu-24.04
     steps:
       - name: checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,65 @@
+---
+name: e2e
+
+on:
+  workflow_call:
+    inputs:
+      debug:
+        description: "start tmate before e2e tests"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # run e2e on main or prs pointing to main
+    if: (github.ref_name == 'main' || github.base_ref == 'main') || inputs.debug
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: pull git lfs assets
+        run: git lfs pull
+
+      - name: load env vars for workflow run
+        run: cat .github/vars.env >> "$GITHUB_ENV"
+
+      - name: set up go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # download pinned tools, create the kind cluster, build the clabernetes
+      # images natively, load them into kind, and install the local helm chart.
+      # these are the exact same make targets developers run locally via
+      # `make test-e2e-local`, so CI and local cannot drift.
+      - name: build images, create kind cluster, and deploy clabernetes
+        run: make e2e-tools e2e-cluster e2e-images e2e-deploy
+
+      # actions seem to be running out of disk for e2e -- probably due to all the image build stuff
+      # floating around, all the junk runners get pre-built with, and runners not being super beefy
+      # lets just system prune all the docker stuff to get rid of some junk we dont need. This is a
+      # ci-only disk hack so it is deliberately kept out of the make targets (it would nuke a
+      # developer's local image cache). the cluster already has the images loaded by this point.
+      - name: docker system prune
+        run: docker system prune -a -f
+
+      - name: setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.debug }}
+
+      - name: run the e2e tests
+        id: run-the-e2e-tests
+        run: make e2e-test
+        continue-on-error: true
+
+      - name: dump logs from controller if tests fail
+        if: steps.run-the-e2e-tests.outcome != 'success'
+        run: |
+          set -x
+          make e2e-debug-dump
+          exit 1

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -12,6 +12,11 @@ on:
         description: "value for the VERSION build-arg"
         type: string
         required: true
+      amd64-only:
+        description: "skip the (much slower) arm64 builds -- for build-only runs, ie push: false"
+        type: boolean
+        required: false
+        default: false
       tags:
         description: "docker/metadata-action tag rules applied to every image"
         type: string
@@ -42,13 +47,12 @@ jobs:
           - name: clabverter
             file: build/clabverter.Dockerfile
             context: "."
-        platform:
-          - arch: amd64
-            target: linux/amd64
-            runner: ubuntu-24.04
-          - arch: arm64
-            target: linux/arm64
-            runner: ubuntu-24.04-arm
+        # same two entries as a plain yaml list would be, just selected by expression so callers can
+        # drop arm64. note that yaml lists cannot be conditional, hence the inline json.
+        platform: >-
+          ${{ inputs.amd64-only
+          && fromJSON('[{"arch":"amd64","target":"linux/amd64","runner":"ubuntu-24.04"}]')
+          || fromJSON('[{"arch":"amd64","target":"linux/amd64","runner":"ubuntu-24.04"},{"arch":"arm64","target":"linux/arm64","runner":"ubuntu-24.04-arm"}]') }}
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
 ---
 name: test
 
-# runs unit then e2e as a single gate. cicd calls unit.yaml/e2e.yaml directly so
-# that image builds can run alongside e2e; everything else wants both together.
+# runs unit then e2e as a single gate. cicd calls unit.yaml/e2e.yaml directly so that pr image
+# builds can run alongside e2e; everything else wants both together.
 on:
   workflow_call: {}
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 ---
 name: test
 
+# runs unit then e2e as a single gate. cicd calls unit.yaml/e2e.yaml directly so
+# that image builds can run alongside e2e; everything else wants both together.
 on:
   workflow_call: {}
   workflow_dispatch:
@@ -18,82 +20,12 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: load env vars for workflow run
-        run: cat .github/vars.env >> "$GITHUB_ENV"
-
-      - name: set up go
-        uses: actions/setup-go@v7
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: install test tools
-        run: make install-test-tools
-
-      - name: setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_unit }}
-
-      - name: run the unit tests
-        run: make test-race
+    uses: ./.github/workflows/unit.yaml
+    with:
+      debug: ${{ inputs.debug_unit || false }}
 
   e2e:
-    runs-on: ubuntu-latest
-    needs:
-      - unit
-    # run e2e on main or prs pointing to main
-    if: (github.ref_name == 'main' || github.base_ref == 'main') || (github.event_name == 'workflow_dispatch' && inputs.debug_e2e)
-    steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          lfs: true
-
-      - name: pull git lfs assets
-        run: git lfs pull
-
-      - name: load env vars for workflow run
-        run: cat .github/vars.env >> "$GITHUB_ENV"
-
-      - name: set up go
-        uses: actions/setup-go@v7
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      # download pinned tools, create the kind cluster, build the clabernetes
-      # images natively, load them into kind, and install the local helm chart.
-      # these are the exact same make targets developers run locally via
-      # `make test-e2e-local`, so CI and local cannot drift.
-      - name: build images, create kind cluster, and deploy clabernetes
-        run: make e2e-tools e2e-cluster e2e-images e2e-deploy
-
-      # actions seem to be running out of disk for e2e -- probably due to all the image build stuff
-      # floating around, all the junk runners get pre-built with, and runners not being super beefy
-      # lets just system prune all the docker stuff to get rid of some junk we dont need. This is a
-      # ci-only disk hack so it is deliberately kept out of the make targets (it would nuke a
-      # developer's local image cache). the cluster already has the images loaded by this point.
-      - name: docker system prune
-        run: docker system prune -a -f
-
-      - name: setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_e2e }}
-
-      - name: run the e2e tests
-        id: run-the-e2e-tests
-        run: make e2e-test
-        continue-on-error: true
-
-      - name: dump logs from controller if tests fail
-        if: steps.run-the-e2e-tests.outcome != 'success'
-        run: |
-          set -x
-          make e2e-debug-dump
-          exit 1
+    needs: unit
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      debug: ${{ inputs.debug_e2e || false }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,38 @@
+---
+name: unit
+
+on:
+  workflow_call:
+    inputs:
+      debug:
+        description: "start tmate before unit tests"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: load env vars for workflow run
+        run: cat .github/vars.env >> "$GITHUB_ENV"
+
+      - name: set up go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: install test tools
+        run: make install-test-tools
+
+      - name: setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ inputs.debug }}
+
+      - name: run the unit tests
+        run: make test-race

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ make e2e-test
 otherwise reuses the existing cluster.
 
 CI runs the exact same `e2e-*` make targets (see
-[.github/workflows/test.yaml](.github/workflows/test.yaml)), so local and CI
+[.github/workflows/e2e.yaml](.github/workflows/e2e.yaml)), so local and CI
 share all of the setup code.
 
 Tear down the e2e cluster with:


### PR DESCRIPTION
Test amd64 only image builds in PRs in parallel with e2e tests for quicker pipelines.

Merges to main and release should gate image builds with e2e tests like before.