### PR TITLE
Install and CI workflow improvements pt2

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,12 +6,6 @@ on:
     branches:
       - main
   pull_request: {}
-  workflow_dispatch:
-    inputs:
-      push:
-        description: "push images and charts to ghcr"
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -28,256 +22,27 @@ jobs:
     needs: unit
     uses: ./.github/workflows/e2e.yaml
 
-  # only computes outputs, so it is deliberately not gated on e2e -- that lets the pr image builds
-  # start alongside e2e while the publishing path below still waits for it.
-  prep:
+  # PRs never push images, so build them alongside e2e purely to prove the builds still work.
+  # amd64 alone is enough of a smoke test there; arm64 builds are covered on main.
+  images:
+    if: ${{ github.event_name == 'pull_request' }}
     needs:
       - lint
       - unit
-    runs-on: ubuntu-24.04
-    outputs:
-      push: ${{ steps.ctx.outputs.push }}
-      short_sha: ${{ steps.ctx.outputs.short_sha }}
-    steps:
-      - name: compute build context
-        id: ctx
-        run: |
-          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          case "${{ github.event_name }}" in
-            push)
-              push=true
-              ;;
-            workflow_dispatch)
-              push=${{ inputs.push }}
-              ;;
-            *)
-              push=false
-              ;;
-          esac
-          echo "push=$push" >> "$GITHUB_OUTPUT"
-
-  # prs never push images, so build them alongside e2e purely to prove the builds still work. amd64
-  # alone is enough of a smoke test there -- arm64 builds are much slower and get covered on merge.
-  images:
-    if: ${{ github.event_name == 'pull_request' }}
-    needs: prep
     uses: ./.github/workflows/images.yaml
     with:
       push: false
       amd64-only: true
-      build-version: 0.0.0-${{ needs.prep.outputs.short_sha }}
+      build-version: 0.0.0-${{ github.sha }}
     secrets: inherit
 
-  # everywhere else the images land in ghcr, so they wait for e2e. e2e skips itself when not
-  # on/targeting main (ie a dispatch from a feature branch) and a skipped need would skip this job
-  # too, hence spelling out the needs results instead of relying on the implicit success gate.
-  images-publish:
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.prep.result == 'success' && needs.e2e.result == 'success' }}
+  publish-dev:
+    if: ${{ github.event_name == 'push' }}
     needs:
-      - prep
+      - lint
+      - unit
       - e2e
-    uses: ./.github/workflows/images.yaml
+    uses: ./.github/workflows/publish-dev.yaml
     with:
-      push: ${{ needs.prep.outputs.push == 'true' }}
-      build-version: 0.0.0-${{ needs.prep.outputs.short_sha }}
+      channel: main
     secrets: inherit
-
-  publish-dev-charts:
-    if: ${{ github.event_name == 'push' }}
-    needs:
-      - prep
-      - images-publish
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: install helm
-        run: make install-helm
-
-      - name: install yq
-        run: make install-yq
-
-      - name: login to ghcr
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: publish helm charts
-        run: |
-          helm registry login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-
-          SOURCE_SHA="${GITHUB_SHA}"
-          RELEASE_VERSION="0.0.0-${GITHUB_SHA::7}"
-          export SOURCE_SHA RELEASE_VERSION
-
-          export MANAGER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-manager:${RELEASE_VERSION}"
-          export LAUNCHER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-launcher:${RELEASE_VERSION}"
-          yq -i eval '.manager.image = strenv(MANAGER_IMAGE) | .globalConfig.deployment.launcherImage = strenv(LAUNCHER_IMAGE)' charts/clabernetes/values.yaml
-          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' charts/clabernetes/Chart.yaml
-          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' charts/clicker/Chart.yaml
-
-          helm package charts/clicker --version 0.0.0
-          helm push clicker-0.0.0.tgz oci://ghcr.io/clabernetes/clabernetes
-
-          # patch clicker dep version so its always same as c9s
-          sed -i \
-            's|    version: (.*)|    version: 0.0.0|g' \
-            charts/clabernetes/Chart.yaml
-          helm package charts/clabernetes --version 0.0.0
-          helm push clabernetes-0.0.0.tgz oci://ghcr.io/clabernetes/clabernetes
-
-          {
-            echo "## Main development artifacts"
-            echo
-            echo "- Source SHA: \`${SOURCE_SHA}\`"
-            echo "- Mutable chart: \`oci://ghcr.io/clabernetes/clabernetes/clabernetes:0.0.0\`"
-            echo "- Manager image: \`${MANAGER_IMAGE}\`"
-            echo "- Launcher image: \`${LAUNCHER_IMAGE}\`"
-            echo
-            echo '```bash'
-            echo "make install VERSION=main"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  publish-custom-charts:
-    if: ${{ github.event_name == 'workflow_dispatch' && needs.prep.outputs.push == 'true' }}
-    needs:
-      - prep
-      - images-publish
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: install helm
-        run: make install-helm
-
-      - name: install yq
-        run: make install-yq
-
-      - name: login to ghcr
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # builds + pushes the charts pinned to this run's build-version image tags, packaged at
-      # 0.0.0-<short_sha> (a valid semver prerelease) so the oci tag is unique and does not
-      # collide with the main/dev 0.0.0 charts.
-      - name: package and push charts
-        run: |
-          RELEASE_VERSION=0.0.0-${{ needs.prep.outputs.short_sha }}
-
-          helm registry login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-
-          make set-chart-versions "$RELEASE_VERSION"
-
-          export MANAGER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-manager:$RELEASE_VERSION"
-          export LAUNCHER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-launcher:$RELEASE_VERSION"
-          echo "manager image->" $MANAGER_IMAGE
-          echo "launcher image->" $LAUNCHER_IMAGE
-          yq -i eval '.manager.image = strenv(MANAGER_IMAGE)' charts/clabernetes/values.yaml
-          yq -i eval '.globalConfig.deployment.launcherImage = strenv(LAUNCHER_IMAGE)' charts/clabernetes/values.yaml
-          export SOURCE_SHA="${GITHUB_SHA}"
-          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' charts/clabernetes/Chart.yaml
-          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' charts/clicker/Chart.yaml
-
-          helm package charts/clicker --version "$RELEASE_VERSION"
-          helm push "clicker-$RELEASE_VERSION.tgz" oci://ghcr.io/clabernetes/clabernetes
-
-          helm package charts/clabernetes --version "$RELEASE_VERSION"
-          helm push "clabernetes-$RELEASE_VERSION.tgz" oci://ghcr.io/clabernetes/clabernetes
-
-          {
-            echo "## Unpublished development artifacts"
-            echo
-            echo "- Source SHA: \`${SOURCE_SHA}\`"
-            echo "- Version: \`${RELEASE_VERSION}\`"
-            echo "- Manager image: \`${MANAGER_IMAGE}\`"
-            echo "- Launcher image: \`${LAUNCHER_IMAGE}\`"
-            echo
-            echo '```bash'
-            echo "make install VERSION=${RELEASE_VERSION}"
-            echo "make try-c9s C9S_VERSION=${RELEASE_VERSION}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  verify-main-artifacts:
-    if: ${{ github.event_name == 'push' }}
-    needs:
-      - publish-dev-charts
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout main source
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-          lfs: true
-
-      - name: load tool versions
-        run: cat .github/vars.env >> "$GITHUB_ENV"
-
-      - name: install mutable main chart in KinD
-        run: make try-c9s C9S_VERSION=main TRY_C9S_TIMEOUT=600s
-
-      - name: clean main smoke cluster
-        if: ${{ always() }}
-        run: make try-c9s-clean || true
-
-  verify-development-artifacts:
-    if: ${{ github.event_name == 'workflow_dispatch' && needs.prep.outputs.push == 'true' }}
-    needs:
-      - prep
-      - images-publish
-      - publish-custom-charts
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: install helm
-        run: make install-helm
-
-      - name: login to ghcr
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: verify exact development artifacts
-        run: |
-          set -euo pipefail
-          VERSION="0.0.0-${GITHUB_SHA::7}"
-          CHART="oci://ghcr.io/clabernetes/clabernetes/clabernetes"
-          helm show chart "$CHART" --version "$VERSION"
-          for image in clabernetes-manager clabernetes-launcher; do
-            docker buildx imagetools inspect "ghcr.io/clabernetes/clabernetes/${image}:${VERSION}" \
-              | tee "${image}.txt"
-            grep -q 'linux/amd64' "${image}.txt"
-            grep -q 'linux/arm64' "${image}.txt"
-          done
-          {
-            echo "## Verified unpublished artifacts"
-            echo
-            echo "- Chart: \`$CHART:$VERSION\`"
-            echo "- Source SHA: \`${GITHUB_SHA}\`"
-            echo "- Manager and launcher manifests include linux/amd64 and linux/arm64."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: smoke install exact development chart
-        run: make try-c9s C9S_VERSION="0.0.0-${GITHUB_SHA::7}" TRY_C9S_TIMEOUT=600s
-
-      - name: clean development smoke cluster
-        if: ${{ always() }}
-        run: make try-c9s-clean || true

--- a/.github/workflows/create-dev-release.yaml
+++ b/.github/workflows/create-dev-release.yaml
@@ -1,0 +1,34 @@
+---
+name: Create dev release
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: "run e2e tests before publishing"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      run_e2e: ${{ inputs.run_e2e }}
+
+  publish:
+    needs:
+      - lint
+      - test
+    if: ${{ !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success' }}
+    uses: ./.github/workflows/publish-dev.yaml
+    with:
+      channel: unpublished
+    secrets: inherit

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,13 +55,6 @@ jobs:
           C9S_LOCAL_REUSE_IMAGES=1 \
           make install C9S_CONTEXT=kind-c9s-e2e C9S_KIND_CLUSTER=c9s-e2e VERSION=local
 
-      - name: verify local try-c9s workflow
-        run: make try-c9s C9S_VERSION=local TRY_C9S_TIMEOUT=600s
-
-      - name: clean local try-c9s workflow
-        if: ${{ always() }}
-        run: make try-c9s-clean || true
-
       - name: setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ inputs.debug }}
@@ -77,3 +70,27 @@ jobs:
           set -x
           make e2e-debug-dump
           exit 1
+
+  try-smoke:
+    runs-on: ubuntu-latest
+    # This job owns a separate KinD cluster and is intentionally independent of the e2e job above.
+    if: (github.ref_name == 'main' || github.base_ref == 'main' || github.event_name == 'workflow_dispatch') || inputs.debug
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: pull git lfs assets
+        run: git lfs pull
+
+      - name: load env vars for workflow run
+        run: cat .github/vars.env >> "$GITHUB_ENV"
+
+      - name: verify local try-c9s workflow
+        run: make try-c9s C9S_VERSION=local TRY_C9S_TIMEOUT=600s
+
+      - name: clean local try-c9s workflow
+        if: ${{ always() }}
+        run: make try-c9s-clean || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
       # these are the exact same make targets developers run locally via
       # `make test-e2e-local`, so CI and local cannot drift.
       - name: build images, create kind cluster, and deploy clabernetes
-        run: make e2e-tools e2e-cluster e2e-images e2e-deploy
+        run: C9S_LOCAL_BUILD_ID="local-${GITHUB_SHA::8}" make e2e-tools e2e-cluster e2e-images e2e-deploy
 
       # actions seem to be running out of disk for e2e -- probably due to all the image build stuff
       # floating around, all the junk runners get pre-built with, and runners not being super beefy
@@ -49,7 +49,11 @@ jobs:
         run: docker system prune -a -f
 
       - name: verify existing-cluster make install
-        run: make install C9S_CONTEXT=kind-c9s-e2e C9S_KIND_CLUSTER=c9s-e2e VERSION=local
+        run: |
+          C9S_LOCAL_BUILD_ID="local-${GITHUB_SHA::8}" \
+          C9S_LOCAL_IMAGE_TAG="local-${GITHUB_SHA::8}" \
+          C9S_LOCAL_REUSE_IMAGES=1 \
+          make install C9S_CONTEXT=kind-c9s-e2e C9S_KIND_CLUSTER=c9s-e2e VERSION=local
 
       - name: verify local try-c9s workflow
         run: make try-c9s C9S_VERSION=local TRY_C9S_TIMEOUT=600s

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,8 +13,6 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    # Run e2e on main, PRs pointing to main, or manually dispatched development builds.
-    if: (github.ref_name == 'main' || github.base_ref == 'main' || github.event_name == 'workflow_dispatch') || inputs.debug
     steps:
       - name: checkout
         uses: actions/checkout@v7
@@ -74,7 +72,6 @@ jobs:
   try-smoke:
     runs-on: ubuntu-latest
     # This job owns a separate KinD cluster and is intentionally independent of the e2e job above.
-    if: (github.ref_name == 'main' || github.base_ref == 'main' || github.event_name == 'workflow_dispatch') || inputs.debug
     steps:
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,0 +1,227 @@
+---
+name: publish development artifacts
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "development channel to publish: main or unpublished"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prep:
+    runs-on: ubuntu-24.04
+    outputs:
+      source_sha: ${{ steps.context.outputs.source_sha }}
+      short_sha: ${{ steps.context.outputs.short_sha }}
+      image_version: ${{ steps.context.outputs.image_version }}
+      chart_version: ${{ steps.context.outputs.chart_version }}
+    steps:
+      - name: compute build context
+        id: context
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          if [[ "$CHANNEL" != "main" && "$CHANNEL" != "unpublished" ]]; then
+            echo "unsupported development channel: $CHANNEL" >&2
+            exit 1
+          fi
+
+          SOURCE_SHA="$GITHUB_SHA"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          IMAGE_VERSION="0.0.0-${SHORT_SHA}"
+          CHART_VERSION="$IMAGE_VERSION"
+          if [[ "$CHANNEL" == "main" ]]; then
+            CHART_VERSION=0.0.0
+          fi
+
+          {
+            echo "source_sha=$SOURCE_SHA"
+            echo "short_sha=$SHORT_SHA"
+            echo "image_version=$IMAGE_VERSION"
+            echo "chart_version=$CHART_VERSION"
+          } >> "$GITHUB_OUTPUT"
+
+  images-publish:
+    needs: prep
+    uses: ./.github/workflows/images.yaml
+    with:
+      push: true
+      build-version: 0.0.0-${{ needs.prep.outputs.short_sha }}
+    secrets: inherit
+
+  publish-charts:
+    needs:
+      - prep
+      - images-publish
+    runs-on: ubuntu-24.04
+    env:
+      CHANNEL: ${{ inputs.channel }}
+      SOURCE_SHA: ${{ needs.prep.outputs.source_sha }}
+      IMAGE_VERSION: ${{ needs.prep.outputs.image_version }}
+      RELEASE_VERSION: ${{ needs.prep.outputs.chart_version }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: install helm
+        run: make install-helm
+
+      - name: install yq
+        run: make install-yq
+
+      - name: login to ghcr
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: package and push charts
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          helm registry login -u "$GITHUB_ACTOR" -p "$GITHUB_TOKEN" ghcr.io
+
+          MANAGER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-manager:${IMAGE_VERSION}"
+          LAUNCHER_IMAGE="ghcr.io/clabernetes/clabernetes/clabernetes-launcher:${IMAGE_VERSION}"
+          export MANAGER_IMAGE LAUNCHER_IMAGE SOURCE_SHA
+
+          if [[ "$CHANNEL" == "unpublished" ]]; then
+            make set-chart-versions "$RELEASE_VERSION"
+          fi
+
+          yq -i eval \
+            '.manager.image = strenv(MANAGER_IMAGE) |
+             .globalConfig.deployment.launcherImage = strenv(LAUNCHER_IMAGE)' \
+            charts/clabernetes/values.yaml
+          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' \
+            charts/clabernetes/Chart.yaml
+          yq -i eval '.annotations."org.opencontainers.image.revision" = strenv(SOURCE_SHA)' \
+            charts/clicker/Chart.yaml
+
+          helm package charts/clicker --version "$RELEASE_VERSION"
+          helm push "clicker-${RELEASE_VERSION}.tgz" oci://ghcr.io/clabernetes/clabernetes
+
+          if [[ "$CHANNEL" == "main" ]]; then
+            # Keep the clicker dependency aligned with the mutable main chart.
+            sed -i \
+              's|    version: (.*)|    version: 0.0.0|g' \
+              charts/clabernetes/Chart.yaml
+          fi
+          helm package charts/clabernetes --version "$RELEASE_VERSION"
+          helm push "clabernetes-${RELEASE_VERSION}.tgz" oci://ghcr.io/clabernetes/clabernetes
+
+          if [[ "$CHANNEL" == "main" ]]; then
+            {
+              echo "## Main development artifacts"
+              echo
+              echo "- Source SHA: \`${SOURCE_SHA}\`"
+              echo "- Mutable chart: \`oci://ghcr.io/clabernetes/clabernetes/clabernetes:0.0.0\`"
+              echo "- Manager image: \`${MANAGER_IMAGE}\`"
+              echo "- Launcher image: \`${LAUNCHER_IMAGE}\`"
+              echo
+              echo '```bash'
+              echo "make install VERSION=main"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Unpublished development artifacts"
+              echo
+              echo "- Source SHA: \`${SOURCE_SHA}\`"
+              echo "- Version: \`${RELEASE_VERSION}\`"
+              echo "- Manager image: \`${MANAGER_IMAGE}\`"
+              echo "- Launcher image: \`${LAUNCHER_IMAGE}\`"
+              echo
+              echo '```bash'
+              echo "make install VERSION=${RELEASE_VERSION}"
+              echo "make try-c9s C9S_VERSION=${RELEASE_VERSION}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  verify:
+    if: ${{ !cancelled() && needs.publish-charts.result == 'success' }}
+    needs:
+      - prep
+      - images-publish
+      - publish-charts
+    runs-on: ubuntu-24.04
+    env:
+      CHANNEL: ${{ inputs.channel }}
+      SOURCE_SHA: ${{ needs.prep.outputs.source_sha }}
+      RELEASE_VERSION: ${{ needs.prep.outputs.chart_version }}
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          lfs: true
+
+      - name: load tool versions
+        run: cat .github/vars.env >> "$GITHUB_ENV"
+
+      - name: install helm
+        run: make install-helm
+
+      - name: login to ghcr
+        if: ${{ inputs.channel == 'unpublished' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: verify published artifacts
+        run: |
+          set -euo pipefail
+          if [[ "$CHANNEL" == "main" ]]; then
+            {
+              echo "## Verified main artifacts"
+              echo
+              echo "- Source SHA: \`${SOURCE_SHA}\`"
+              echo "- Chart: \`oci://ghcr.io/clabernetes/clabernetes/clabernetes:0.0.0\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            CHART="oci://ghcr.io/clabernetes/clabernetes/clabernetes"
+            helm show chart "$CHART" --version "$RELEASE_VERSION"
+            for image in clabernetes-manager clabernetes-launcher; do
+              docker buildx imagetools inspect \
+                "ghcr.io/clabernetes/clabernetes/${image}:${RELEASE_VERSION}" \
+                | tee "${image}.txt"
+              grep -q 'linux/amd64' "${image}.txt"
+              grep -q 'linux/arm64' "${image}.txt"
+            done
+            {
+              echo "## Verified unpublished artifacts"
+              echo
+              echo "- Chart: \`$CHART:$RELEASE_VERSION\`"
+              echo "- Source SHA: \`${SOURCE_SHA}\`"
+              echo "- Manager and launcher manifests include linux/amd64 and linux/arm64."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: smoke install published main chart
+        if: ${{ inputs.channel == 'main' }}
+        run: make try-c9s C9S_VERSION=main TRY_C9S_TIMEOUT=600s
+
+      - name: smoke install exact unpublished chart
+        if: ${{ inputs.channel == 'unpublished' }}
+        run: make try-c9s C9S_VERSION="$RELEASE_VERSION" TRY_C9S_TIMEOUT=600s
+
+      - name: clean smoke cluster
+        if: ${{ always() }}
+        run: make try-c9s-clean || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: release
 on:
   release:
     types:
-      - created
+      - published
 
 permissions:
   contents: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,23 @@
 ---
 name: test
 
-# runs unit then e2e as a single gate. cicd calls unit.yaml/e2e.yaml directly so that pr image
-# builds can run alongside e2e; everything else wants both together.
+# Runs unit then optionally e2e as a single gate. CI calls unit.yaml/e2e.yaml directly so that PR
+# image builds can run alongside e2e; other entrypoints use this workflow as one test gate.
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      run_e2e:
+        description: "run e2e after unit tests"
+        type: boolean
+        required: false
+        default: true
   workflow_dispatch:
     inputs:
+      run_e2e:
+        description: "run e2e after unit tests"
+        type: boolean
+        required: false
+        default: true
       debug_unit:
         description: "start tmate before unit tests"
         type: boolean
@@ -26,6 +37,7 @@ jobs:
 
   e2e:
     needs: unit
+    if: ${{ inputs.run_e2e || inputs.debug_e2e }}
     uses: ./.github/workflows/e2e.yaml
     with:
       debug: ${{ inputs.debug_e2e || false }}

--- a/.mk/install.mk
+++ b/.mk/install.mk
@@ -1,7 +1,6 @@
 ## Existing-cluster c9s installation
 ## ----------------------------------------------------------------------------|
 
-# c9s version to install
 VERSION ?= latest
 C9S_CONTEXT ?=
 C9S_CHART_REF ?= oci://ghcr.io/clabernetes/clabernetes/clabernetes
@@ -9,11 +8,12 @@ C9S_HELM_RELEASE ?= clabernetes
 C9S_NAMESPACE ?= $(NS)
 C9S_INSTALL_TIMEOUT ?= 10m
 C9S_IMAGE_TRANSPORT ?=
-C9S_REGISTRY ?=
+C9S_REGISTRY ?= ghcr.io/clabernetes/clabernetes
 C9S_KIND_CLUSTER ?=
 C9S_LOCAL_IMAGE_TAG ?= $(C9S_LOCAL_BUILD_ID)
-C9S_RELEASE_RESOLVER := $(abspath hack/c9s_releases.py)
-C9S_HELM_WAIT_ARG := $(if $(filter v4%,$(HELM_VERSION)),--wait=legacy,--wait)
+C9S_LOCAL_REUSE_IMAGES ?= 0
+C9S_LOCAL_REBUILD ?= 0
+C9S_INSTALL_SCRIPT := $(abspath hack/c9s_install.py)
 
 .PHONY: c9s-install-tools
 c9s-install-tools: $(GH) $(HELM) $(UV) $(KUBECTL) $(YQ) ## Download tools needed for an existing-cluster c9s install
@@ -23,178 +23,35 @@ c9s-local-tools: $(KIND) ## Download KinD for a local-source installation
 
 .PHONY: c9s-preflight
 c9s-preflight: c9s-install-tools ## Validate the selected Kubernetes context before installation
-	@set -eu; \
-	context="$(C9S_CONTEXT)"; \
-	if [ -z "$$context" ]; then \
-		context="$$($(KUBECTL) config current-context 2>/dev/null || true)"; \
-	fi; \
-	if [ -z "$$context" ]; then \
-		echo "--> C9S: no Kubernetes context selected; set C9S_CONTEXT or configure a current context" >&2; \
-		exit 1; \
-	fi; \
-	if ! $(KUBECTL) config get-contexts "$$context" >/dev/null 2>&1; then \
-		echo "--> C9S: Kubernetes context $$context was not found" >&2; \
-		exit 1; \
-	fi; \
-	if ! $(KUBECTL) --context "$$context" get --raw=/version --request-timeout=15s >/dev/null 2>&1; then \
-		echo "--> C9S: Kubernetes API for context $$context is unreachable or unauthenticated" >&2; \
-		exit 1; \
-	fi; \
-	nodes="$$($(KUBECTL) --context "$$context" get nodes -o name 2>/dev/null || true)"; \
-	if [ -z "$$nodes" ]; then \
-		echo "--> C9S: context $$context returned no nodes or node listing is forbidden" >&2; \
-		exit 1; \
-	fi; \
-	for permission in "create customresourcedefinitions.apiextensions.k8s.io" "create clusterroles.rbac.authorization.k8s.io"; do \
-		if [ "$$($(KUBECTL) --context "$$context" auth can-i $$permission 2>/dev/null || true)" != "yes" ]; then \
-			echo "--> C9S: context $$context lacks permission: $$permission" >&2; \
-			exit 1; \
-		fi; \
-	done; \
-	if ! $(KUBECTL) --context "$$context" get namespace "$(C9S_NAMESPACE)" >/dev/null 2>&1 && \
-		[ "$$($(KUBECTL) --context "$$context" auth can-i create namespaces 2>/dev/null || true)" != "yes" ]; then \
-		echo "--> C9S: context $$context cannot create namespace $(C9S_NAMESPACE)" >&2; \
-		exit 1; \
-	fi; \
-	echo "--> C9S: Kubernetes context $$context passed preflight ($$(printf '%s\n' "$$nodes" | wc -l) node(s))"
+	@$(UV) run --script "$(C9S_INSTALL_SCRIPT)" preflight \
+		--context "$(C9S_CONTEXT)" \
+		--kubectl "$(abspath $(KUBECTL))" \
+		--namespace "$(C9S_NAMESPACE)"
 
 .PHONY: c9s-install
-c9s-install: c9s-preflight ## Install c9s into the selected existing Kubernetes context
-	@set -eu; \
-	context="$(C9S_CONTEXT)"; \
-	if [ -z "$$context" ]; then context="$$($(KUBECTL) config current-context)"; fi; \
-	selection="$(VERSION)"; \
-	chart_ref="$(C9S_CHART_REF)"; \
-	image_args=""; \
-	manager_image=""; \
-	launcher_image=""; \
-	source_sha=""; \
-	case "$$selection" in \
-		local) \
-			$(MAKE) --no-print-directory c9s-local-tools; \
-			if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then \
-				echo "--> C9S: local source installation requires a reachable Docker daemon" >&2; \
-				exit 1; \
-			fi; \
-			platforms="$$($(KUBECTL) --context "$$context" get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.operatingSystem}/{.status.nodeInfo.architecture}{"\n"}{end}' | sort -u)"; \
-			if [ "$$(printf '%s\n' "$$platforms" | awk 'NF {count++} END {print count+0}')" -ne 1 ]; then \
-				echo "--> C9S: local source requires one cluster platform; found: $$platforms" >&2; \
-				exit 1; \
-			fi; \
-			target_platform="$$platforms"; \
-			cluster="$(C9S_KIND_CLUSTER)"; \
-			if [ -z "$$cluster" ] && printf '%s' "$$context" | grep -Eq '^kind-'; then cluster="$${context#kind-}"; fi; \
-			if [ -n "$$cluster" ] && $(KIND) get clusters 2>/dev/null | grep -Fxq "$$cluster"; then \
-				$(MAKE) --no-print-directory build-manager build-launcher IMAGE_TAG="$(C9S_LOCAL_IMAGE_TAG)" TARGET_PLATFORM="$$target_platform" C9S_LOCAL_BUILD_ID="$(C9S_LOCAL_BUILD_ID)"; \
-				$(KIND) load docker-image "$(MANAGER_IMAGE):$(C9S_LOCAL_IMAGE_TAG)" --name "$$cluster"; \
-				$(KIND) load docker-image "$(LAUNCHER_IMAGE):$(C9S_LOCAL_IMAGE_TAG)" --name "$$cluster"; \
-				manager_image="$(MANAGER_IMAGE):$(C9S_LOCAL_IMAGE_TAG)"; \
-				launcher_image="$(LAUNCHER_IMAGE):$(C9S_LOCAL_IMAGE_TAG)"; \
-			elif [ -n "$(C9S_REGISTRY)" ]; then \
-				registry="$${C9S_REGISTRY%/}"; \
-				manager_image="$$registry/clabernetes-manager:$(C9S_LOCAL_IMAGE_TAG)"; \
-				launcher_image="$$registry/clabernetes-launcher:$(C9S_LOCAL_IMAGE_TAG)"; \
-				REGISTRY="$$registry" UV="$(UV)" bash .develop/ensure-registry-auth.sh; \
-				$(MAKE) --no-print-directory build-manager build-launcher IMAGE_TAG="$(C9S_LOCAL_IMAGE_TAG)" TARGET_PLATFORM="$$target_platform" C9S_LOCAL_BUILD_ID="$(C9S_LOCAL_BUILD_ID)" MANAGER_IMAGE="$${manager_image%:*}" LAUNCHER_IMAGE="$${launcher_image%:*}"; \
-				docker push "$$manager_image"; \
-				docker push "$$launcher_image"; \
-			else \
-				echo "--> C9S: local source requires a verified KinD cluster or C9S_REGISTRY" >&2; \
-				exit 1; \
-			fi; \
-			chart_ref="./charts/clabernetes"; \
-			version="0.0.0"; \
-			channel="local checkout"; \
-			image_args="--set manager.image=$$manager_image --set manager.imagePullPolicy=IfNotPresent --set globalConfig.deployment.launcherImage=$$launcher_image --set globalConfig.deployment.launcherImagePullPolicy=IfNotPresent" ;; \
-		latest) \
-			version="$$($(UV) run --script "$(C9S_RELEASE_RESOLVER)" resolve latest --gh "$(abspath $(GH))")"; \
-			channel="latest stable" ;; \
-		main) \
-			version="0.0.0"; \
-			channel="mutable main" ;; \
-		select) \
-			version="$$($(UV) run --script "$(C9S_RELEASE_RESOLVER)" select --gh "$(abspath $(GH))" --helm "$(abspath $(HELM))")"; \
-			channel="selected artifact" ;; \
-		*) \
-			version="$$($(UV) run --script "$(C9S_RELEASE_RESOLVER)" resolve "$$selection" --gh "$(abspath $(GH))")"; \
-			channel="exact artifact" ;; \
-	esac; \
-	echo "--> C9S: probing $$channel chart version $$version"; \
-	if ! $(HELM) show chart "$$chart_ref" --version "$$version" >/dev/null; then \
-		echo "--> C9S: OCI chart $$version is unavailable; no cluster changes were made" >&2; \
-		exit 1; \
-	fi; \
-	selected_group="$$($(HELM) show crds "$$chart_ref" --version "$$version" | $(YQ) -r 'select(.spec.group == "c9s.run" or .spec.group == "clabernetes.containerlab.dev") | .spec.group' | awk 'NF {print; exit}')"; \
-	installed_groups="$$($(KUBECTL) --context "$$context" get crd -o jsonpath='{range .items[*]}{.spec.group}{"\n"}{end}' 2>/dev/null | grep -E '^(c9s\.run|clabernetes\.containerlab\.dev)$$' | sort -u || true)"; \
-	if [ -n "$$selected_group" ] && [ -n "$$installed_groups" ] && ! printf '%s\n' "$$installed_groups" | grep -Fxq "$$selected_group"; then \
-		echo "--> C9S: selected chart uses $$selected_group but cluster has $$installed_groups CRDs" >&2; \
-		echo "--> C9S: run make uninstall-c9s C9S_CONTEXT=$$context before crossing the API-group boundary; this deletes all c9s custom resources" >&2; \
-		exit 1; \
-	fi; \
-	if [ "$$version" = "0.0.0" ] || printf '%s' "$$version" | grep -Eq '^0\.0\.0-[0-9a-f]{7,40}$$'; then \
-		chart_metadata="$$($(HELM) show chart "$$chart_ref" --version "$$version")"; \
-		source_sha="$$(printf '%s\n' "$$chart_metadata" | $(YQ) -r '.annotations."org.opencontainers.image.revision" // ""')"; \
-		values="$$($(HELM) show values "$$chart_ref" --version "$$version")"; \
-		manager_image="$$(printf '%s\n' "$$values" | $(YQ) -r '.manager.image // ""')"; \
-		launcher_image="$$(printf '%s\n' "$$values" | $(YQ) -r '.globalConfig.deployment.launcherImage // ""')"; \
-		if ! printf '%s' "$$source_sha" | grep -Eq '^[0-9a-f]{40}$$'; then \
-			echo "--> C9S: development chart $$version has no full source revision metadata" >&2; \
-			exit 1; \
-		fi; \
-		expected_tag="$$version"; \
-		if [ "$$version" = "0.0.0" ]; then expected_tag="0.0.0-$$(printf '%.7s' "$$source_sha")"; fi; \
-		case "$$manager_image" in *:"$$expected_tag") ;; *) echo "--> C9S: development chart manager image does not use $$expected_tag" >&2; exit 1 ;; esac; \
-		case "$$launcher_image" in *:"$$expected_tag") ;; *) echo "--> C9S: development chart launcher image does not use $$expected_tag" >&2; exit 1 ;; esac; \
-		echo "--> C9S: verified development source $$source_sha and image tag $$expected_tag"; \
-	fi; \
-	if [ -z "$$manager_image" ]; then \
-		manager_image="ghcr.io/clabernetes/clabernetes/clabernetes-manager:$$version"; \
-		if [ "$$version" = "0.0.0" ]; then manager_image="ghcr.io/clabernetes/clabernetes/clabernetes-manager:dev-latest"; fi; \
-	fi; \
-	if [ -z "$$launcher_image" ]; then \
-		launcher_image="ghcr.io/clabernetes/clabernetes/clabernetes-launcher:$$version"; \
-		if [ "$$version" = "0.0.0" ]; then launcher_image="ghcr.io/clabernetes/clabernetes/clabernetes-launcher:dev-latest"; fi; \
-	fi; \
-	proxy_args=""; \
-	http_proxy_val="$${HTTP_PROXY:-$${http_proxy:-}}"; \
-	https_proxy_val="$${HTTPS_PROXY:-$${https_proxy:-}}"; \
-	if [ -n "$$http_proxy_val" ] || [ -n "$$https_proxy_val" ]; then \
-		pod_cidrs="$$($(KUBECTL) --context "$$context" get nodes -o json | $(YQ) -r '[.items[].spec.podCIDRs[]] | join(",")')"; \
-		service_cidrs="$$($(KUBECTL) --context "$$context" -n kube-system get configmap kubeadm-config -o jsonpath='{.data.ClusterConfiguration}' 2>/dev/null | $(YQ) -r '.networking.serviceSubnet // ""')"; \
-		if [ -z "$$pod_cidrs" ] || [ -z "$$service_cidrs" ]; then \
-			echo "--> C9S: proxy environment detected but pod/service CIDRs could not be discovered" >&2; \
-			exit 1; \
-		fi; \
-		no_proxy_val="$${NO_PROXY:-$${no_proxy:-}}"; \
-		no_proxy_val="$${no_proxy_val:+$$no_proxy_val,}$$service_cidrs,$$pod_cidrs,.svc,.svc.cluster.local,localhost,127.0.0.1"; \
-		extra_env_json="$$(C9S_HTTP_PROXY="$$http_proxy_val" C9S_HTTPS_PROXY="$$https_proxy_val" C9S_NO_PROXY="$$no_proxy_val" $(YQ) -n -o=json -I=0 '[{"name":"HTTP_PROXY","value":strenv(C9S_HTTP_PROXY)},{"name":"http_proxy","value":strenv(C9S_HTTP_PROXY)},{"name":"HTTPS_PROXY","value":strenv(C9S_HTTPS_PROXY)},{"name":"https_proxy","value":strenv(C9S_HTTPS_PROXY)},{"name":"NO_PROXY","value":strenv(C9S_NO_PROXY)},{"name":"no_proxy","value":strenv(C9S_NO_PROXY)}] | map(select(.value != ""))')"; \
-		proxy_args="--set-json globalConfig.deployment.extraEnv=$$extra_env_json"; \
-	fi; \
-	echo "--> C9S: installing chart $$version into context $$context"; \
-	$(HELM) --kube-context "$$context" upgrade --install "$(C9S_HELM_RELEASE)" "$$chart_ref" \
-		--version "$$version" \
+c9s-install: c9s-install-tools ## Install c9s into the selected existing Kubernetes context
+	@$(UV) run --script "$(C9S_INSTALL_SCRIPT)" install \
+		--version "$(VERSION)" \
+		--context "$(C9S_CONTEXT)" \
+		--chart "$(C9S_CHART_REF)" \
+		--release "$(C9S_HELM_RELEASE)" \
 		--namespace "$(C9S_NAMESPACE)" \
-		--create-namespace \
-		$(C9S_HELM_WAIT_ARG) \
 		--timeout "$(C9S_INSTALL_TIMEOUT)" \
-		--set manager.replicaCount=1 \
-		$$image_args \
-		$$proxy_args; \
-	$(KUBECTL) --context "$$context" -n "$(C9S_NAMESPACE)" rollout status deploy/clabernetes-manager --timeout="$(C9S_INSTALL_TIMEOUT)"; \
-	observed_manager_image="$$($(KUBECTL) --context "$$context" -n "$(C9S_NAMESPACE)" get deploy/clabernetes-manager -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}')"; \
-	case "$$observed_manager_image" in *:"$${manager_image##*:}") ;; *) echo "--> C9S: manager image mismatch: expected $$manager_image, observed $$observed_manager_image" >&2; exit 1 ;; esac; \
-	echo "--> C9S: waiting for Config singleton in $$selected_group"; \
-	config_resource="configs.$$selected_group"; \
-	config_ready=""; \
-	for attempt in $$(seq 1 60); do \
-		if $(KUBECTL) --context "$$context" -n "$(C9S_NAMESPACE)" get "$$config_resource/clabernetes" >/dev/null 2>&1; then config_ready=1; break; fi; \
-		sleep 1; \
-	done; \
-	if [ -z "$$config_ready" ]; then echo "--> C9S: Config singleton did not become available" >&2; exit 1; fi; \
-	$(KUBECTL) --context "$$context" -n "$(C9S_NAMESPACE)" patch "$$config_resource/clabernetes" --type=merge -p "{\"spec\":{\"deployment\":{\"launcherImage\":\"$$launcher_image\",\"launcherImagePullPolicy\":\"IfNotPresent\"}}}"; \
-	observed_launcher_image="$$($(KUBECTL) --context "$$context" -n "$(C9S_NAMESPACE)" get "$$config_resource/clabernetes" -o jsonpath='{.spec.deployment.launcherImage}')"; \
-	if [ "$$observed_launcher_image" != "$$launcher_image" ]; then echo "--> C9S: launcher image mismatch: expected $$launcher_image, observed $$observed_launcher_image" >&2; exit 1; fi; \
-	echo "--> C9S: installed $$channel chart=$$version source=$${source_sha:-$$channel} context=$$context namespace=$(C9S_NAMESPACE) manager=$$observed_manager_image launcher=$$observed_launcher_image"
+		--image-transport "$(C9S_IMAGE_TRANSPORT)" \
+		--registry "$(C9S_REGISTRY)" \
+		--kind-cluster "$(C9S_KIND_CLUSTER)" \
+		--local-image-tag "$(C9S_LOCAL_IMAGE_TAG)" \
+		--build-id "$(C9S_LOCAL_BUILD_ID)" \
+		--rebuild-local-images "$(C9S_LOCAL_REBUILD)" \
+		--reuse-local-images "$(C9S_LOCAL_REUSE_IMAGES)" \
+		--repo-root "$(CURDIR)" \
+		--gh "$(abspath $(GH))" \
+		--helm "$(abspath $(HELM))" \
+		--kubectl "$(abspath $(KUBECTL))" \
+		--kind "$(abspath $(KIND))" \
+		--yq "$(abspath $(YQ))" \
+		--uv "$(abspath $(UV))" \
+		--helm-version "$(HELM_VERSION)"
 
 .PHONY: install
 install: c9s-install ## Install c9s into the current or C9S_CONTEXT Kubernetes cluster

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,34 @@ C9S_RELEASE_SCRIPT := hack/c9s_releases.py
 C9S_RELEASE_LIMIT ?= 10
 C9S_RELEASE_WORKERS ?= 8
 C9S_GIT_SHA := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)
-C9S_DIRTY_SUFFIX := $(if $(shell git status --porcelain --untracked-files=normal),-dirty-$(shell date +%s),)
+# Keep this list aligned with the build context allowed by .dockerignore. Documentation, CI,
+# development configuration, e2e fixtures, charts, and other operator-only files must not change
+# local runtime image identities.
+C9S_IMAGE_INPUT_PATHS := \
+	.dockerignore \
+	go.mod \
+	go.sum \
+	apis \
+	assets \
+	cmd \
+	clabverter \
+	clicker \
+	config \
+	constants \
+	controllers \
+	generated \
+	http \
+	launcher \
+	logging \
+	manager \
+	util \
+	build/launcher \
+	build/manager.Dockerfile \
+	build/launcher.Dockerfile \
+	build/clabverter.Dockerfile
+C9S_IMAGE_INPUT_STATUS := $(shell for path in $(C9S_IMAGE_INPUT_PATHS); do git status --porcelain -- "$$path"; done)
+C9S_WORKTREE_HASH := $(shell { for path in $(C9S_IMAGE_INPUT_PATHS); do git ls-files --cached --others --exclude-standard -- "$$path"; done | sort -u | while IFS= read -r file; do printf '%s\t' "$$file"; git hash-object "$$file"; done; } | sha256sum | cut -c1-12)
+C9S_DIRTY_SUFFIX := $(if $(C9S_IMAGE_INPUT_STATUS),-dirty-$(C9S_WORKTREE_HASH),)
 C9S_LOCAL_BUILD_ID ?= local-$(C9S_GIT_SHA)$(C9S_DIRTY_SUFFIX)
 
 ifeq ($(USE_UV),true)
@@ -236,13 +263,13 @@ delete-generated: ## Deletes all zz_*.go (generated) files, and crds
 	rm -rf generated/*
 
 build-manager: ## Builds the clabernetes manager container; typically built via devspace, but this is a handy shortcut for one offs. Override the tag with IMAGE_TAG.
-	docker build --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(MANAGER_IMAGE):$(IMAGE_TAG) -f ./build/manager.Dockerfile .
+	docker buildx build --load --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(MANAGER_IMAGE):$(IMAGE_TAG) -f ./build/manager.Dockerfile .
 
 build-launcher: ## Builds the clabernetes launcher container; typically built via devspace, but this is a handy shortcut for one offs. Override the tag with IMAGE_TAG.
-	docker build --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(LAUNCHER_IMAGE):$(IMAGE_TAG) -f ./build/launcher.Dockerfile .
+	docker buildx build --load --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(LAUNCHER_IMAGE):$(IMAGE_TAG) -f ./build/launcher.Dockerfile .
 
 build-clabverter: ## Builds the clabverter container; typically built via devspace, but this is a handy shortcut for one offs. Override the tag with IMAGE_TAG.
-	docker build --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(CLABVERTER_IMAGE):$(IMAGE_TAG) -f ./build/clabverter.Dockerfile .
+	docker buildx build --load --platform="$(TARGET_PLATFORM)" --build-arg BUILDPLATFORM="$(TARGET_PLATFORM)" --build-arg VERSION=$(C9S_LOCAL_BUILD_ID) -t $(CLABVERTER_IMAGE):$(IMAGE_TAG) -f ./build/clabverter.Dockerfile .
 
 set-chart-versions: ## Sets the helm chart versions to the given value.
 	./hack/set-chart-versions.sh $(BUMP_CHART_VERSION_ARGS)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,17 +95,19 @@ does not start DevSpace or its source-sync workflow.
 
 ## Development artifacts
 
-An authorized developer can download the pinned GitHub CLI and dispatch the `cicd` workflow against
-a repository branch or tag:
+An authorized developer can download the pinned GitHub CLI and dispatch the `Create dev release`
+workflow against a repository branch or tag. The workflow always runs lint and unit tests; e2e is
+optional and is off by default:
 
 ```bash
 make c9s-release-tools
-build/try-c9s/bin/gh-v2.97.0 workflow run cicd.yaml --ref feature/my-change -f push=true
+build/try-c9s/bin/gh-v2.97.0 workflow run create-dev-release.yaml \
+  --ref feature/my-change -f run_e2e=false
 ```
 
-After lint, unit, e2e, image, and chart publication complete, the workflow summary reports the
+After the selected checks, image, and chart publication complete, the workflow summary reports the
 resolved full SHA and exact commands. The chart and images use `0.0.0-<short-sha>` and no GitHub
-Release is created:
+Release is created. Set `run_e2e=true` when the development artifact needs the full e2e gate:
 
 ```bash
 make install VERSION=0.0.0-abc1234

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,9 +52,39 @@ C9S_CONTEXT=kind-my-cluster C9S_KIND_CLUSTER=my-cluster \
 ```
 
 The cluster must report one operating-system/architecture pair. Local images receive a unique
-checkout/dirty-worktree identity and use `IfNotPresent`.
+checkout/dirty-worktree identity and use `IfNotPresent`. Images are built with Buildx and loaded
+with `--load`. Repeated installs reuse the local Docker images for the same identity; force a
+rebuild with:
 
-For a non-KinD cluster, set a registry prefix that every node can pull from:
+```bash
+C9S_LOCAL_REBUILD=1 VERSION=local make install
+```
+
+### Local image identity
+
+The local tag encodes the source state used to build the images:
+
+```text
+local-37c83b52-dirty-f8a82871162e
+│     │        │
+│     │        └─ deterministic worktree hash
+│     └────────── dirty checkout marker
+└──────────────── commit SHA
+```
+
+For a clean checkout the tag is `local-<commit-sha>`. For a dirty checkout, the worktree hash is
+calculated only from image-input paths allowed by the repository Docker context: source code, Go
+metadata, image Dockerfiles, and launcher assets. Paths excluded by `.dockerignore`, such as
+`docs/`, do not affect it. The same source state therefore produces the same tag on repeated
+installs.
+
+On a repeat install, the installer checks whether both tagged images already exist locally. If they
+do, it skips the Buildx build, loads the cached images into KinD when needed, and reapplies the Helm
+release using the same immutable references. A changed worktree produces a new hash and therefore a
+new tag. `C9S_LOCAL_REBUILD=1` forces rebuilding the current tag.
+
+For a non-KinD cluster, local images are pushed to
+`ghcr.io/clabernetes/clabernetes` by default. Override the registry prefix when needed:
 
 ```bash
 C9S_REGISTRY=ghcr.io/example/c9s make install VERSION=local

--- a/hack/c9s_install.py
+++ b/hack/c9s_install.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "rich",
+#   "typer",
+# ]
+# ///
+
+"""Install c9s with explicit, testable orchestration steps."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn
+
+import typer  # ty: ignore[unresolved-import]
+from rich.console import Console  # ty: ignore[unresolved-import]
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+console = Console()
+error_console = Console(stderr=True)
+
+DEFAULT_CHART = "oci://ghcr.io/clabernetes/clabernetes/clabernetes"
+DEFAULT_IMAGE_BASE = "ghcr.io/clabernetes/clabernetes"
+RELEASE_SCRIPT = Path(__file__).with_name("c9s_releases.py")
+CONTEXT_OPTION = typer.Option("")
+NAMESPACE_OPTION = typer.Option("c9s")
+REPO_ROOT_OPTION = typer.Option(..., exists=True, file_okay=False)
+GH_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+HELM_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+KUBECTL_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+KIND_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+YQ_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+UV_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+
+
+@dataclass(frozen=True)
+class Tools:
+    gh: Path
+    helm: Path
+    kubectl: Path
+    kind: Path
+    yq: Path
+    uv: Path
+    helm_version: str
+
+
+@dataclass(frozen=True)
+class Cluster:
+    context: str
+    namespace: str
+    platforms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Images:
+    manager: str
+    launcher: str
+
+
+def fail(message: str) -> NoReturn:
+    error_console.print(f"[red]error:[/red] {message}")
+    raise typer.Exit(1)
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = False,
+    input_text: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> str:
+    environment = os.environ.copy()
+    if extra_env:
+        environment.update(extra_env)
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            input=input_text,
+            text=True,
+            capture_output=capture,
+            check=True,
+            env=environment,
+        )
+    except FileNotFoundError:
+        fail(f"executable was not found: {command[0]}")
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip().splitlines()
+        fail(detail[-1] if detail else f"command failed: {' '.join(command)}")
+    return result.stdout if capture else ""
+
+
+def json_command(command: list[str], *, cwd: Path | None = None) -> Any:
+    try:
+        return json.loads(run(command, cwd=cwd, capture=True))
+    except json.JSONDecodeError:
+        fail(f"command returned invalid JSON: {' '.join(command)}")
+
+
+def require_executable(path: Path, name: str) -> None:
+    if not path.is_absolute() or not path.is_file() or not os.access(path, os.X_OK):
+        fail(f"{name} is not an executable repository-local binary: {path}")
+
+
+def kubectl(cluster: Cluster, tools: Tools, *args: str) -> list[str]:
+    return [str(tools.kubectl), "--context", cluster.context, *args]
+
+
+def current_context(tools: Tools, requested: str) -> str:
+    if requested:
+        return requested
+    return run([str(tools.kubectl), "config", "current-context"], capture=True).strip()
+
+
+def node_data(cluster: Cluster, tools: Tools) -> dict[str, Any]:
+    return json_command(kubectl(cluster, tools, "get", "nodes", "-o", "json"))
+
+
+def discover_cluster(
+    tools: Tools,
+    context: str,
+    namespace: str,
+) -> Cluster:
+    context = current_context(tools, context)
+    if not context:
+        fail("no Kubernetes context selected; set C9S_CONTEXT")
+    run([str(tools.kubectl), "config", "get-contexts", context], capture=True)
+    cluster = Cluster(context=context, namespace=namespace, platforms=())
+    run(
+        kubectl(cluster, tools, "get", "--raw=/version", "--request-timeout=15s"),
+        capture=True,
+    )
+    nodes = node_data(cluster, tools)
+    items = nodes.get("items", [])
+    platforms = tuple(
+        sorted(
+            {
+                f"{item['status']['nodeInfo']['operatingSystem']}/{item['status']['nodeInfo']['architecture']}"
+                for item in items
+            }
+        )
+    )
+    if not platforms:
+        fail(f"context {context} returned no nodes")
+    for permission in (
+        "create customresourcedefinitions.apiextensions.k8s.io",
+        "create clusterroles.rbac.authorization.k8s.io",
+    ):
+        if (
+            run(
+                kubectl(cluster, tools, "auth", "can-i", *permission.split()),
+                capture=True,
+            ).strip()
+            != "yes"
+        ):
+            fail(f"context {context} lacks permission: {permission}")
+    namespace_exists = (
+        subprocess.run(
+            kubectl(cluster, tools, "get", "namespace", namespace),
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+    if not namespace_exists and (
+        run(
+            kubectl(cluster, tools, "auth", "can-i", "create", "namespaces"),
+            capture=True,
+        ).strip()
+        != "yes"
+    ):
+        fail(f"context {context} cannot create namespace {namespace}")
+    return Cluster(context=context, namespace=namespace, platforms=platforms)
+
+
+def yq(tools: Tools, expression: str, value: str) -> str:
+    return run(
+        [str(tools.yq), "-r", expression], capture=True, input_text=value
+    ).strip()
+
+
+def resolve_version(tools: Tools, value: str) -> str:
+    return run(
+        [
+            str(tools.uv),
+            "run",
+            "--script",
+            str(RELEASE_SCRIPT),
+            "resolve",
+            value,
+            "--gh",
+            str(tools.gh),
+        ],
+        capture=True,
+    ).strip()
+
+
+def chart_crd_group(tools: Tools, chart: str, version: str) -> str:
+    crds = run(
+        [str(tools.helm), "show", "crds", chart, "--version", version],
+        capture=True,
+    )
+    return yq(
+        tools,
+        'select(.spec.group == "c9s.run" or .spec.group == "clabernetes.containerlab.dev") | .spec.group',
+        crds,
+    ).splitlines()[0]
+
+
+def ensure_api_group(tools: Tools, cluster: Cluster, selected: str) -> None:
+    groups = run(
+        kubectl(
+            cluster,
+            tools,
+            "get",
+            "crd",
+            "-o",
+            'jsonpath={range .items[*]}{.spec.group}{"\\n"}{end}',
+        ),
+        capture=True,
+    )
+    installed = {
+        line
+        for line in groups.splitlines()
+        if line in {"c9s.run", "clabernetes.containerlab.dev"}
+    }
+    if installed and selected not in installed:
+        fail(
+            f"selected chart uses {selected} but cluster has {', '.join(sorted(installed))} CRDs; "
+            f"run make uninstall-c9s C9S_CONTEXT={cluster.context} before crossing the API-group boundary"
+        )
+
+
+def kind_cluster(tools: Tools, cluster: Cluster, requested: str) -> str:
+    name = requested or (
+        cluster.context.removeprefix("kind-")
+        if cluster.context.startswith("kind-")
+        else ""
+    )
+    clusters = run([str(tools.kind), "get", "clusters"], capture=True).splitlines()
+    if not name or name not in clusters:
+        fail("local source requires a KinD cluster; set C9S_KIND_CLUSTER")
+    return name
+
+
+def docker_image_present(reference: str) -> bool:
+    return (
+        subprocess.run(
+            ["docker", "image", "inspect", reference],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def build_local_images(
+    tools: Tools,
+    cluster: Cluster,
+    *,
+    repo_root: Path,
+    image_tag: str,
+    build_id: str,
+    kind_name: str,
+    registry: str,
+    reuse: bool,
+    rebuild: bool,
+) -> Images:
+    manager = f"{DEFAULT_IMAGE_BASE}/clabernetes-manager:{image_tag}"
+    launcher = f"{DEFAULT_IMAGE_BASE}/clabernetes-launcher:{image_tag}"
+    if reuse:
+        return Images(manager=manager, launcher=launcher)
+    if shutil.which("docker") is None:
+        fail("local source installation requires Docker")
+    run(["docker", "info"], capture=True)
+    run(["docker", "buildx", "version"], capture=True)
+    if len(cluster.platforms) != 1:
+        fail(
+            f"local source requires one cluster platform; found {', '.join(cluster.platforms)}"
+        )
+    platform = cluster.platforms[0]
+    if kind_name:
+        if rebuild or not (
+            docker_image_present(manager) and docker_image_present(launcher)
+        ):
+            run(
+                [
+                    "make",
+                    "--no-print-directory",
+                    "build-manager",
+                    "build-launcher",
+                    f"IMAGE_TAG={image_tag}",
+                    f"TARGET_PLATFORM={platform}",
+                    f"C9S_LOCAL_BUILD_ID={build_id}",
+                ],
+                cwd=repo_root,
+            )
+        run([str(tools.kind), "load", "docker-image", manager, "--name", kind_name])
+        run([str(tools.kind), "load", "docker-image", launcher, "--name", kind_name])
+        return Images(manager=manager, launcher=launcher)
+    if not registry:
+        fail("local source requires a KinD cluster or C9S_REGISTRY")
+    registry = registry.rstrip("/")
+    manager = f"{registry}/clabernetes-manager:{image_tag}"
+    launcher = f"{registry}/clabernetes-launcher:{image_tag}"
+    run(
+        ["bash", ".develop/ensure-registry-auth.sh"],
+        cwd=repo_root,
+        extra_env={"REGISTRY": registry, "UV": str(tools.uv)},
+    )
+    if rebuild or not (
+        docker_image_present(manager) and docker_image_present(launcher)
+    ):
+        run(
+            [
+                "make",
+                "--no-print-directory",
+                "build-manager",
+                "build-launcher",
+                f"IMAGE_TAG={image_tag}",
+                f"TARGET_PLATFORM={platform}",
+                f"C9S_LOCAL_BUILD_ID={build_id}",
+                f"MANAGER_IMAGE={manager.rsplit(':', 1)[0]}",
+                f"LAUNCHER_IMAGE={launcher.rsplit(':', 1)[0]}",
+            ],
+            cwd=repo_root,
+        )
+    run(["docker", "push", manager])
+    run(["docker", "push", launcher])
+    return Images(manager=manager, launcher=launcher)
+
+
+def chart_images(tools: Tools, chart: str, version: str) -> Images:
+    values = run(
+        [str(tools.helm), "show", "values", chart, "--version", version], capture=True
+    )
+    manager = yq(tools, '.manager.image // ""', values)
+    launcher = yq(tools, '.globalConfig.deployment.launcherImage // ""', values)
+    if not manager:
+        manager = f"{DEFAULT_IMAGE_BASE}/clabernetes-manager:{'dev-latest' if version == '0.0.0' else version}"
+    if not launcher:
+        launcher = f"{DEFAULT_IMAGE_BASE}/clabernetes-launcher:{'dev-latest' if version == '0.0.0' else version}"
+    return Images(manager=manager, launcher=launcher)
+
+
+def proxy_values(tools: Tools, cluster: Cluster) -> str | None:
+    http_proxy = os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy", "")
+    https_proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy", "")
+    if not http_proxy and not https_proxy:
+        return None
+    nodes = node_data(cluster, tools)
+    pod_cidrs = ",".join(
+        cidr
+        for item in nodes.get("items", [])
+        for cidr in item.get("spec", {}).get("podCIDRs", [])
+    )
+    config = run(
+        kubectl(
+            cluster,
+            tools,
+            "-n",
+            "kube-system",
+            "get",
+            "configmap",
+            "kubeadm-config",
+            "-o",
+            "jsonpath={.data.ClusterConfiguration}",
+        ),
+        capture=True,
+    )
+    service_cidr = yq(tools, '.networking.serviceSubnet // ""', config)
+    if not pod_cidrs or not service_cidr:
+        fail("proxy environment detected but pod/service CIDRs could not be discovered")
+    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy", "")
+    no_proxy = ",".join(
+        filter(
+            None,
+            [
+                no_proxy,
+                service_cidr,
+                pod_cidrs,
+                ".svc",
+                ".svc.cluster.local",
+                "localhost",
+                "127.0.0.1",
+            ],
+        )
+    )
+    env = [
+        {"name": name, "value": value}
+        for name, value in (
+            ("HTTP_PROXY", http_proxy),
+            ("http_proxy", http_proxy),
+            ("HTTPS_PROXY", https_proxy),
+            ("https_proxy", https_proxy),
+            ("NO_PROXY", no_proxy),
+            ("no_proxy", no_proxy),
+        )
+        if value
+    ]
+    return json.dumps(env, separators=(",", ":"))
+
+
+def install(
+    version: str,
+    context: str,
+    chart: str,
+    release: str,
+    namespace: str,
+    timeout: str,
+    image_transport: str,
+    registry: str,
+    kind_name: str,
+    local_image_tag: str,
+    build_id: str,
+    rebuild_local_images: str,
+    reuse_local_images: str,
+    repo_root: Path,
+    gh: Path,
+    helm: Path,
+    kubectl_path: Path,
+    kind: Path,
+    yq_path: Path,
+    uv: Path,
+    helm_version: str,
+) -> None:
+    tools = Tools(gh, helm, kubectl_path, kind, yq_path, uv, helm_version)
+    cluster = discover_cluster(tools, context, namespace)
+    selection = version
+    source = "local checkout" if selection == "local" else selection
+    chart_ref = chart
+    images: Images | None = None
+    if selection == "select":
+        selected_version = run(
+            [
+                str(tools.uv),
+                "run",
+                "--script",
+                str(RELEASE_SCRIPT),
+                "select",
+                "--gh",
+                str(tools.gh),
+                "--helm",
+                str(tools.helm),
+            ],
+            capture=True,
+        ).strip()
+    elif selection in {"local", "main"}:
+        selected_version = "0.0.0"
+    else:
+        selected_version = resolve_version(tools, selection)
+    if selection == "local":
+        candidate_kind = kind_name or (
+            cluster.context.removeprefix("kind-")
+            if cluster.context.startswith("kind-")
+            else ""
+        )
+        if reuse_local_images == "1":
+            kind_name = kind_cluster(tools, cluster, candidate_kind)
+        else:
+            existing_kinds = run(
+                [str(tools.kind), "get", "clusters"], capture=True
+            ).splitlines()
+            kind_name = candidate_kind if candidate_kind in existing_kinds else ""
+        images = build_local_images(
+            tools,
+            cluster,
+            repo_root=repo_root,
+            image_tag=local_image_tag,
+            build_id=build_id,
+            kind_name=kind_name,
+            registry=registry,
+            reuse=reuse_local_images == "1",
+            rebuild=rebuild_local_images == "1",
+        )
+        chart_ref = "./charts/clabernetes"
+    elif image_transport == "in-cluster":
+        fail("C9S_IMAGE_TRANSPORT=in-cluster is not implemented")
+
+    run(
+        [str(helm), "show", "chart", chart_ref, "--version", selected_version],
+        capture=True,
+    )
+    ensure_api_group(
+        tools, cluster, chart_crd_group(tools, chart_ref, selected_version)
+    )
+    if images is None:
+        images = chart_images(tools, chart_ref, selected_version)
+    helm_args = [
+        str(helm),
+        "--kube-context",
+        cluster.context,
+        "upgrade",
+        "--install",
+        release,
+        chart_ref,
+        "--version",
+        selected_version,
+        "--namespace",
+        namespace,
+        "--create-namespace",
+        "--wait=legacy" if helm_version.startswith("v4") else "--wait",
+        "--timeout",
+        timeout,
+        "--set",
+        "manager.replicaCount=1",
+        "--set",
+        f"manager.image={images.manager}",
+        "--set",
+        "manager.imagePullPolicy=IfNotPresent",
+        "--set",
+        f"globalConfig.deployment.launcherImage={images.launcher}",
+        "--set",
+        "globalConfig.deployment.launcherImagePullPolicy=IfNotPresent",
+    ]
+    proxy = proxy_values(tools, cluster)
+    if proxy:
+        helm_args.extend(["--set-json", f"globalConfig.deployment.extraEnv={proxy}"])
+    run(helm_args)
+    run(
+        kubectl(
+            cluster,
+            tools,
+            "-n",
+            namespace,
+            "rollout",
+            "status",
+            "deploy/clabernetes-manager",
+            f"--timeout={timeout}",
+        )
+    )
+    manager_observed = run(
+        kubectl(
+            cluster,
+            tools,
+            "-n",
+            namespace,
+            "get",
+            "deploy/clabernetes-manager",
+            "-o",
+            'jsonpath={.spec.template.spec.containers[?(@.name=="manager")].image}',
+        ),
+        capture=True,
+    ).strip()
+    if manager_observed != images.manager:
+        fail(
+            f"manager image mismatch: expected {images.manager}, observed {manager_observed}"
+        )
+    config_resource = f"configs.{chart_crd_group(tools, chart_ref, selected_version)}"
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            kubectl(
+                cluster, tools, "-n", namespace, "get", f"{config_resource}/clabernetes"
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            break
+        time.sleep(1)
+    else:
+        fail("Config singleton did not become available")
+    patch = json.dumps(
+        {
+            "spec": {
+                "deployment": {
+                    "launcherImage": images.launcher,
+                    "launcherImagePullPolicy": "IfNotPresent",
+                }
+            }
+        },
+        separators=(",", ":"),
+    )
+    run(
+        kubectl(
+            cluster,
+            tools,
+            "-n",
+            namespace,
+            "patch",
+            f"{config_resource}/clabernetes",
+            "--type=merge",
+            "-p",
+            patch,
+        )
+    )
+    launcher_observed = run(
+        kubectl(
+            cluster,
+            tools,
+            "-n",
+            namespace,
+            "get",
+            f"{config_resource}/clabernetes",
+            "-o",
+            "jsonpath={.spec.deployment.launcherImage}",
+        ),
+        capture=True,
+    ).strip()
+    if launcher_observed != images.launcher:
+        fail(
+            f"launcher image mismatch: expected {images.launcher}, observed {launcher_observed}"
+        )
+    console.print(
+        f"Installed [bold]{source}[/bold] chart={selected_version} "
+        f"context={cluster.context} namespace={namespace} "
+        f"manager={manager_observed} launcher={launcher_observed}"
+    )
+
+
+@app.command()
+def preflight(
+    context: str = CONTEXT_OPTION,
+    kubectl: Path = KUBECTL_PATH_OPTION,
+    namespace: str = NAMESPACE_OPTION,
+) -> None:
+    """Validate an existing Kubernetes context."""
+    tools = Tools(kubectl, kubectl, kubectl, kubectl, kubectl, kubectl, "")
+    cluster = discover_cluster(tools, context, namespace)
+    console.print(
+        f"Kubernetes context {cluster.context} passed preflight ({len(cluster.platforms)} node platform(s))"
+    )
+
+
+def install_command(
+    version: str = typer.Option(..., "--version"),
+    context: str = CONTEXT_OPTION,
+    chart: str = typer.Option(DEFAULT_CHART),
+    release: str = typer.Option("clabernetes"),
+    namespace: str = NAMESPACE_OPTION,
+    timeout: str = typer.Option("10m"),
+    image_transport: str = typer.Option(""),
+    registry: str = typer.Option(""),
+    kind_cluster: str = typer.Option(""),
+    local_image_tag: str = typer.Option(...),
+    build_id: str = typer.Option(...),
+    rebuild_local_images: str = typer.Option("0"),
+    reuse_local_images: str = typer.Option("0"),
+    repo_root: Path = REPO_ROOT_OPTION,
+    gh: Path = GH_PATH_OPTION,
+    helm: Path = HELM_PATH_OPTION,
+    kubectl: Path = KUBECTL_PATH_OPTION,
+    kind: Path = KIND_PATH_OPTION,
+    yq: Path = YQ_PATH_OPTION,
+    uv: Path = UV_PATH_OPTION,
+    helm_version: str = typer.Option(""),
+) -> None:
+    """Install and verify c9s."""
+    for path, name in (
+        (gh, "gh"),
+        (helm, "helm"),
+        (kubectl, "kubectl"),
+        (kind, "kind"),
+        (yq, "yq"),
+        (uv, "uv"),
+    ):
+        require_executable(path, name)
+    install(
+        version,
+        context,
+        chart,
+        release,
+        namespace,
+        timeout,
+        image_transport,
+        registry,
+        kind_cluster,
+        local_image_tag,
+        build_id,
+        rebuild_local_images,
+        reuse_local_images,
+        repo_root,
+        gh,
+        helm,
+        kubectl,
+        kind,
+        yq,
+        uv,
+        helm_version,
+    )
+
+
+app.command("install")(install_command)
+
+if __name__ == "__main__":
+    app()

--- a/hack/c9s_install.py
+++ b/hack/c9s_install.py
@@ -36,7 +36,7 @@ REPO_ROOT_OPTION = typer.Option(..., exists=True, file_okay=False)
 GH_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
 HELM_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
 KUBECTL_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
-KIND_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
+KIND_PATH_OPTION = typer.Option(..., dir_okay=False)
 YQ_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
 UV_PATH_OPTION = typer.Option(..., exists=True, dir_okay=False)
 
@@ -461,6 +461,8 @@ def install(
     else:
         selected_version = resolve_version(tools, selection)
     if selection == "local":
+        run(["make", "--no-print-directory", "c9s-local-tools"], cwd=repo_root)
+        require_executable(tools.kind, "kind")
         candidate_kind = kind_name or (
             cluster.context.removeprefix("kind-")
             if cluster.context.startswith("kind-")
@@ -663,7 +665,6 @@ def install_command(
         (gh, "gh"),
         (helm, "helm"),
         (kubectl, "kubectl"),
-        (kind, "kind"),
         (yq, "yq"),
         (uv, "uv"),
     ):

--- a/hack/c9s_releases.py
+++ b/hack/c9s_releases.py
@@ -169,7 +169,7 @@ def _development_builds(
 ) -> list[DevelopmentBuild]:
     payload = _gh_json(
         gh,
-        f"repos/{repository}/actions/workflows/cicd.yaml/runs"
+        f"repos/{repository}/actions/workflows/create-dev-release.yaml/runs"
         "?event=workflow_dispatch&status=completed&per_page=100",
     )
     runs = _flatten_pages(payload, key="workflow_runs")

--- a/hack/test_c9s_releases.py
+++ b/hack/test_c9s_releases.py
@@ -44,7 +44,7 @@ if endpoint.endswith("/releases/latest"):
         "draft": False,
         "html_url": "https://example.test/v0.6.0"
     }]))
-elif "/actions/workflows/" in endpoint:
+elif "/actions/workflows/create-dev-release.yaml/runs" in endpoint:
     print(json.dumps([{
         "workflow_runs": [{
             "head_sha": "abc1234567890",
@@ -52,6 +52,16 @@ elif "/actions/workflows/" in endpoint:
             "conclusion": "success",
             "updated_at": "2026-08-10T10:00:00Z",
             "html_url": "https://example.test/run"
+        }]
+    }]))
+elif "/actions/workflows/cicd.yaml/runs" in endpoint:
+    print(json.dumps([{
+        "workflow_runs": [{
+            "head_sha": "def5678901234",
+            "head_branch": "main",
+            "conclusion": "success",
+            "updated_at": "2026-08-11T10:00:00Z",
+            "html_url": "https://example.test/main-run"
         }]
     }]))
 else:
@@ -156,6 +166,7 @@ sys.exit(0 if version in {"0.5.0", "0.6.0"} else 1)
         builds = MODULE._development_builds(self.gh, "example/repo")
         self.assertEqual(builds[0].version, "0.0.0-abc1234")
         self.assertEqual(builds[0].branch, "feature")
+        self.assertEqual(MODULE._main_build(self.gh, "example/repo").version, "0.0.0")
 
     def test_github_cli_failure_is_reported_as_exit(self) -> None:
         failing_gh = Path(self.directory.name) / "failing-gh"

--- a/openspec/changes/installation/design.md
+++ b/openspec/changes/installation/design.md
@@ -8,7 +8,7 @@ The repository currently has three materially different deployment paths:
 
 There is no c9s `make install` target for an existing cluster. The paths also disagree on tool versions and installation identity. The current live `c9s-e2e` cluster illustrates the observability problem: Helm reports chart `0.0.0`, the images are mutable `dev-latest` tags, and the old binary does not expose a usable version flag.
 
-The `cicd` workflow already has two development publication paths. A main push overwrites OCI chart `0.0.0`; because its image values are empty, chart templates currently resolve manager and launcher to mutable `dev-latest`. A manual dispatch with `push=true` builds multi-architecture images and a chart as `0.0.0-<short-sha>`, with the chart values pinned to matching image tags and no GitHub Release object. Manual feature-branch dispatch currently skips e2e, and the only observed historical manual run completed successfully but its commit artifacts are no longer available, so workflow success alone is not an installability guarantee.
+The `cicd` workflow handles pull requests and main pushes. A main push overwrites OCI chart `0.0.0`; because its image values were empty, chart templates could resolve manager and launcher to mutable `dev-latest`. A separate `Create dev release` manual workflow builds a selected branch or tag as multi-architecture images and a chart at `0.0.0-<short-sha>`, with chart values pinned to matching image tags and no GitHub Release object. Both paths retain exact artifact probing and install smoke because workflow success alone is not an installability guarantee.
 
 Published and checkout resources are not necessarily compatible. At proposal time, GitHub's latest release is `v0.6.0`; its chart installs `clabernetes.containerlab.dev` CRDs, while the checkout demo and chart use `c9s.run`. Helm does not perform an in-place migration between those groups, and the existing `crd-api-group` specification requires uninstall/reinstall.
 
@@ -112,7 +112,7 @@ The script provides commands for listing, selecting, and resolving releases. It:
 - writes Rich UI to stderr and only the selected normalized value to stdout when called by Make;
 - reports API rate-limit and network failures without a traceback.
 
-The selector also exposes a distinct development view. It presents `main` as a moving channel and obtains recent manually dispatched build candidates from successful `cicd` workflow runs through `gh api` against the GitHub Actions API. Action completion is labeled as workflow completion, not release publication or package push time. A development candidate is still installable only after the exact OCI chart probe succeeds.
+The selector also exposes a distinct development view. It presents `main` as a moving channel and obtains recent manually dispatched build candidates from successful `Create dev release` workflow runs through `gh api` against the GitHub Actions API. Action completion is labeled as workflow completion, not release publication or package push time. A development candidate is still installable only after the exact OCI chart probe succeeds.
 
 The public `make ls-releases` target produces a Rich table of all installable c9s artifacts: GitHub
 Releases, the mutable `main` chart at `0.0.0`, and successful manual development builds at
@@ -138,12 +138,12 @@ Alternative considered: use shell and `gh api` without Python. Rejected because 
 
 ### 4. Model unpublished commit and main artifacts as development channels
 
-Keep the existing `cicd` workflow as the publisher rather than creating a second release-shaped workflow.
+Keep `cicd` focused on pull-request validation and main-merge publication, and use a separate `Create dev release` entrypoint for ad-hoc publication. Both call one reusable development publisher rather than duplicating the image, chart, metadata, verification, and smoke implementation.
 
 For manual unpublished builds:
 
-1. An authorized developer dispatches `cicd` on the feature branch or tag that points at the desired repository commit, with package push enabled.
-2. Lint, unit, and e2e validate that exact workflow ref. Publication does not proceed when a required check fails.
+1. An authorized developer dispatches `Create dev release` on the feature branch or tag that points at the desired repository commit and chooses whether to run e2e.
+2. Lint and unit always validate that exact workflow ref; e2e runs when selected. Publication does not proceed when any required check fails.
 3. Manager, launcher, and clabverter multi-architecture images are published as `0.0.0-<short-sha>`.
 4. Clicker and c9s charts are published at the same version. The c9s values pin manager and launcher to those exact tags.
 5. Chart `appVersion` or an equivalent chart annotation records the full source SHA.
@@ -294,7 +294,7 @@ KinD acceptance uses the same public Make targets and covers:
 - cleanup and uninstall;
 - poisoned host PATH to prove absolute pinned tools.
 
-Workflow tests and smoke checks cover manual feature-ref dispatch metadata, e2e publication gating, exact commit images/chart, generated handoff commands, mutable main chart source metadata, main chart image pinning, and demo retrieval by source revision.
+Workflow tests and smoke checks cover the `Create dev release` feature-ref dispatch, mandatory lint/unit and optional e2e publication gates, exact commit images/chart, generated handoff commands, mutable main chart source metadata, main chart image pinning, and demo retrieval by source revision.
 
 CI provides linux/amd64 gating coverage and linux/arm64 smoke coverage without multiplying every selector across every platform. The release workflow adds an exact-version install smoke after images and charts are pushed; a failed smoke fails the release workflow even though the current GitHub release object may already be visible.
 
@@ -316,7 +316,7 @@ CI provides linux/amd64 gating coverage and linux/arm64 smoke coverage without m
 ## Migration Plan
 
 1. Add stable/development selection and fixture tests without changing existing targets.
-2. Harden manual and main development publication with source metadata, exact image pins, e2e gating, artifact probes, install smoke, and handoff output.
+2. Separate routine CI from `Create dev release`, then harden manual and main development publication with source metadata, exact image pins, optional e2e gating, artifact probes, install smoke, and handoff output.
 3. Consolidate tool pins and local binary paths; prove e2e and existing developer workflows still use the intended versions.
 4. Introduce the shared install core and new `make install`.
 5. Migrate `try-c9s` to the shared core, release/source-revision demo selection, idempotent KinD handling, and hard readiness failure.

--- a/openspec/changes/installation/design.md
+++ b/openspec/changes/installation/design.md
@@ -211,7 +211,10 @@ For local source, apply the checkout's `examples/basic/srl-multitool.yaml`.
 
 For supported published source, retrieve the demo from the immutable selected Git tag rather than from the checkout. The guaranteed published-demo support floor is `v0.6.0`, where the stable path exists. The release selector may list older releases, and `make install` may install an older exact chart after a successful OCI probe, but `make try-c9s` rejects releases below the demo support floor with an actionable message.
 
-For `main` and exact unpublished commit builds, retrieve the demo from the full source revision embedded in the chart metadata. Fail before applying resources if the chart lacks source metadata or that revision's demo is unavailable.
+For `main` and exact unpublished commit builds, the try workflow retrieves the demo from the full
+source revision embedded in the chart metadata. It fails before applying resources if the chart
+lacks source metadata or that revision's demo is unavailable. The existing-cluster install does not
+perform this metadata check.
 
 The demo manifest is stored in the try state directory before application. Readiness timeout dumps topology state, pods, events, and manager/launcher logs, then returns failure. The current soft-success behavior is removed.
 
@@ -222,7 +225,7 @@ Alternative considered: maintain duplicate legacy demos on `main`. Rejected beca
 Local manager and launcher builds share one generated identity:
 
 - clean checkout: `local-<short-commit>`;
-- dirty checkout: `local-<short-commit>-dirty-<build-id>`.
+- dirty checkout with image-input changes: `local-<short-commit>-dirty-<worktree-hash>`.
 
 The same identity is:
 
@@ -233,7 +236,9 @@ The same identity is:
 
 The installer detects the cluster's single node platform and passes it to BuildKit. Mixed-platform clusters fail unless future work adds a multi-platform push implementation.
 
-Unique dirty-build identities prevent `IfNotPresent` and an unchanged Pod template from reusing stale content.
+The worktree hash follows the image Docker context, so documentation and other excluded files do not
+invalidate the image identity. Unique identities for changed image inputs prevent `IfNotPresent` and
+an unchanged Pod template from reusing stale content.
 
 ### 10. Select image transport by cluster type and explicit user choice
 
@@ -262,14 +267,15 @@ It uses the API group derived from the selected chart. It does not set chart boo
 
 The installer then verifies:
 
-- Helm release and chart version/source;
+- Helm release, chart version, and selected channel;
 - manager Deployment image;
 - Config launcher image and pull policy;
 - manager rollout;
 - embedded manager version where the selected binary exposes it;
 - local build identity for both local images.
 
-Any mismatch fails with the expected and observed values. Successful output displays context, namespace, Helm release, source, chart, manager image, launcher image, and observed binary version.
+Any mismatch fails with the expected and observed values. Successful output displays context,
+namespace, Helm release, channel, chart, manager image, launcher image, and observed binary version.
 
 ### 12. Test the public contract in layers
 

--- a/openspec/changes/installation/proposal.md
+++ b/openspec/changes/installation/proposal.md
@@ -7,7 +7,7 @@ c9s installation is split across `try-c9s`, e2e, DevSpace, and manual Helm flows
 - Introduce one shared installation workflow used by `make try-c9s` and a new `make install`, while keeping cluster creation, MetalLB, and demo resources exclusive to `try-c9s`.
 - Support stable, development, and local selections through a common version contract: `VERSION` for `make install` and `C9S_VERSION` for `make try-c9s`, covering latest stable release, exact published release, mutable main, exact unpublished commit build, local checkout, and interactive selection.
 - Add a repository-local UV/PEP 723 CLI using Rich and Typer that invokes a pinned repository-local GitHub CLI for authenticated/paginated JSON, lists releases and development builds with accurate timestamps, and returns machine-readable selections to Make.
-- Harden the existing manually dispatched `cicd` workflow as the unpublished-build path: build and test a selected feature ref, publish multi-architecture images and a chart as `0.0.0-<short-sha>`, attach full source revision metadata, verify the artifacts, and print exact install/try commands without creating a GitHub Release.
+- Keep `cicd` as the pull-request and main-merge pipeline with no publication toggle, always publishing main artifacts after a successful merge. Add a separate `Create dev release` manual workflow that selects a branch or tag, always runs lint and unit tests, optionally runs e2e, and publishes multi-architecture images and a chart as `0.0.0-<short-sha>` without creating a GitHub Release.
 - Treat the existing `0.0.0` chart as an explicit mutable `main` channel rather than as “latest”; publish it with full source revision metadata and manager/launcher values pinned to the same main commit instead of relying on floating `dev-latest` image resolution.
 - Validate the selected Kubernetes context and exact OCI artifact before mutating a cluster, then verify the Helm chart, manager image, launcher image, rollout, and embedded version after installation.
 - Reuse the e2e local image build/load path for KinD. Require an explicit pullable registry for local-checkout installation into non-KinD clusters, while leaving the development in-cluster registry as an opt-in transport rather than an installation default.
@@ -35,6 +35,6 @@ c9s installation is split across `try-c9s`, e2e, DevSpace, and manual Helm flows
 - Local manager and launcher image tagging/version embedding, KinD loading, and registry push paths.
 - Helm invocation and Config launcher-image reconciliation without overwriting unrelated user configuration.
 - GitHub Actions for install acceptance and exact-release smoke testing.
-- Existing `cicd` manual dispatch and main-push chart publication behavior.
+- Main `cicd` publication, the `Create dev release` manual workflow, and the GitHub-release publication workflow.
 - Root README, Make help, chart README, quickstart, installation, upgrading, and troubleshooting documentation.
 - External systems: GitHub Releases API, GHCR OCI charts/images, Docker/BuildKit, KinD, Helm, and Kubernetes API/RBAC.

--- a/openspec/changes/installation/specs/development-builds/spec.md
+++ b/openspec/changes/installation/specs/development-builds/spec.md
@@ -2,11 +2,11 @@
 
 ### Requirement: Manually dispatched unpublished build
 
-The repository SHALL provide an authorized GitHub Actions manual dispatch that builds an unpublished c9s artifact set from the exact commit resolved by a selected repository branch or tag ref. The workflow SHALL publish OCI artifacts without creating a GitHub Release.
+The repository SHALL provide an authorized `Create dev release` GitHub Actions manual dispatch that builds an unpublished c9s artifact set from the exact commit resolved by a selected repository branch or tag ref. The workflow SHALL publish OCI artifacts without creating a GitHub Release and SHALL NOT expose a publish/no-publish option.
 
 #### Scenario: Build a feature branch head
 
-- **WHEN** a developer dispatches the workflow with package push enabled on a feature branch
+- **WHEN** a developer dispatches the workflow on a feature branch
 - **THEN** the workflow resolves and records that branch's full head SHA and builds artifacts from that commit
 
 #### Scenario: Build a tagged commit
@@ -45,12 +45,17 @@ An unpublished build SHALL use version `0.0.0-<short-sha>` for its manager, laun
 
 ### Requirement: Unpublished build validation gate
 
-An unpublished artifact publication SHALL require successful lint, unit, e2e, multi-architecture image publication, chart publication, exact artifact probes, and an exact-version installation smoke. Publication or handoff SHALL not be reported as successful when a required gate fails.
+An unpublished artifact publication SHALL require successful lint and unit checks, and SHALL require successful e2e checks when the `run_e2e` input is enabled. It SHALL also require multi-architecture image publication, chart publication, exact artifact probes, and an exact-version installation smoke. Publication or handoff SHALL not be reported as successful when a required gate fails.
 
-#### Scenario: Feature branch e2e fails
+#### Scenario: Selected feature branch e2e fails
 
 - **WHEN** e2e fails for a manually dispatched feature build
 - **THEN** image/chart publication or successful handoff is blocked
+
+#### Scenario: E2E is not selected
+
+- **WHEN** a developer dispatches `Create dev release` with `run_e2e` set to false
+- **THEN** the workflow runs lint and unit, skips e2e, and may publish only after those required checks succeed
 
 #### Scenario: Published image lacks a required platform
 

--- a/openspec/changes/installation/specs/development-builds/spec.md
+++ b/openspec/changes/installation/specs/development-builds/spec.md
@@ -102,7 +102,7 @@ Every successful main publication SHALL overwrite OCI chart `0.0.0` as the expli
 
 ### Requirement: Development artifact installation
 
-The `make install` workflow SHALL treat `VERSION=main` as exact chart version `0.0.0` in the development channel and SHALL accept exact unpublished versions matching `0.0.0-<sha>`. The `make try-c9s` workflow SHALL accept the equivalent values through `C9S_VERSION`. Both SHALL read full source revision metadata from development charts, probe the exact chart and referenced images, and SHALL never classify either channel as latest stable.
+The `make install` workflow SHALL treat `VERSION=main` as exact chart version `0.0.0` in the development channel and SHALL accept exact unpublished versions matching `0.0.0-<sha>`. The `make try-c9s` workflow SHALL accept the equivalent values through `C9S_VERSION`. Both SHALL probe the exact chart and SHALL never classify either channel as latest stable. Only the try workflow requires source-revision metadata to retrieve a matching demo.
 
 #### Scenario: Install mutable main
 
@@ -117,7 +117,7 @@ The `make install` workflow SHALL treat `VERSION=main` as exact chart version `0
 #### Scenario: Development chart lacks source metadata
 
 - **WHEN** a selected main or unpublished chart does not record a full source revision
-- **THEN** installation fails before cluster mutation with an invalid-development-artifact error
+- **THEN** `make install` may proceed when the exact chart is available, while `make try-c9s` refuses to apply a source-mismatched demo
 
 #### Scenario: Development workflow run exists but artifacts do not
 

--- a/openspec/changes/installation/specs/installation-workflows/spec.md
+++ b/openspec/changes/installation/specs/installation-workflows/spec.md
@@ -98,7 +98,7 @@ Before mutating a cluster, `make install` SHALL capture `C9S_CONTEXT` or the cur
 
 ### Requirement: Exact remote artifact validation
 
-For every stable or development remote source, the installer SHALL probe the exact normalized OCI chart version before invoking Helm and SHALL install with an explicit `--version`. It SHALL NOT rely on Helm's unversioned chart resolution or a mutable image tag to implement latest-release selection. Development charts SHALL additionally provide a full source revision and explicit manager and launcher image references.
+For every stable or development remote source, the installer SHALL probe the exact normalized OCI chart version before invoking Helm and SHALL install with an explicit `--version`. It SHALL NOT rely on Helm's unversioned chart resolution or a mutable image tag to implement latest-release selection. The installer SHALL resolve manager and launcher image references from the selected chart values when they are explicitly provided, without requiring source-revision metadata.
 
 #### Scenario: Selected release artifacts are ready
 
@@ -123,11 +123,11 @@ For every stable or development remote source, the installer SHALL probe the exa
 #### Scenario: Unpublished chart is selected
 
 - **WHEN** the user selects `0.0.0-abc1234`
-- **THEN** installation probes that exact chart and fails before mutation if its source metadata or matching images are unavailable
+- **THEN** installation probes that exact chart and fails before mutation only when the chart itself is unavailable
 
 ### Requirement: Identifiable local builds
 
-For local source, the installer SHALL build manager and launcher images for the target cluster's single node platform, SHALL give both images one unique build identity, SHALL pass that identity through the Docker `VERSION` build argument, and SHALL use the same identity in Helm values and the success summary. A dirty checkout identity SHALL differ between builds so an unchanged mutable tag cannot hide changed source.
+For local source, the installer SHALL build manager and launcher images for the target cluster's single node platform, SHALL give both images one unique build identity, SHALL pass that identity through the Docker `VERSION` build argument, and SHALL use the same identity in Helm values and the success summary. A dirty checkout identity SHALL differ when image-input files change, while files excluded by `.dockerignore` SHALL NOT change the identity.
 
 #### Scenario: Clean checkout build
 

--- a/openspec/changes/installation/specs/release-selection/spec.md
+++ b/openspec/changes/installation/specs/release-selection/spec.md
@@ -36,7 +36,7 @@ The repository SHALL provide `make ls-releases`, backed by the UV-run release CL
 
 #### Scenario: Unpublished development chart is available
 
-- **WHEN** a successful manual `cicd` workflow has published chart `0.0.0-abc1234`
+- **WHEN** a successful manual `Create dev release` workflow has published chart `0.0.0-abc1234`
 - **THEN** the catalog includes a distinct development row with Version `0.0.0-abc1234`, which can be supplied as `C9S_VERSION=0.0.0-abc1234`, plus source branch, workflow URL, and workflow-availability timestamp
 
 #### Scenario: Displayed version is install input
@@ -195,11 +195,11 @@ A GitHub release catalog entry SHALL be treated as a candidate until the install
 
 ### Requirement: Development build discovery
 
-The CLI SHALL present `main` as a distinct mutable channel and SHALL discover recent unpublished-build candidates from manually dispatched `cicd` workflow runs through the GitHub Actions API. It SHALL display the source branch, short SHA version, workflow completion time, and workflow URL without describing those values as release publication or package push metadata.
+The CLI SHALL present `main` as a distinct mutable channel and SHALL discover recent unpublished-build candidates from manually dispatched `Create dev release` workflow runs through the GitHub Actions API. It SHALL display the source branch, short SHA version, workflow completion time, and workflow URL without describing those values as release publication or package push metadata.
 
 #### Scenario: Successful manual build candidate
 
-- **WHEN** a completed successful `cicd` manual run reports source SHA `abc1234...`
+- **WHEN** a completed successful `Create dev release` manual run reports source SHA `abc1234...`
 - **THEN** the development catalog presents candidate version `0.0.0-abc1234`, its source branch, workflow completion time, and run link
 
 #### Scenario: Failed or incomplete manual run

--- a/openspec/changes/installation/tasks.md
+++ b/openspec/changes/installation/tasks.md
@@ -14,17 +14,17 @@
 - [x] 2.5 Add `make ls-releases` to concurrently probe stable, main, and development OCI charts and render the newest 10 installable artifacts in a Rich table sorted by publication/availability time, with `ALL=1` displaying the complete catalog without requiring cluster access.
 - [x] 2.6 Wire `VERSION=latest|main|vX.Y.Z|X.Y.Z|0.0.0-<sha>|local|select` into `make install` and the equivalent `C9S_VERSION` selections into `make try-c9s`, while keeping an unset value non-interactive.
 - [x] 2.7 Add fixture-based script tests for GitHub CLI JSON/subprocess failures, multi-page and unordered responses, drafts, prereleases, unavailable OCI charts, bounded newest-first results, concurrent probes, tags with and without `v`, latest-stable semantics, cancellation, malformed values, authentication, rate limits, network errors, and malformed API data.
-- [x] 2.8 Add a development catalog backed by recent successful manual `cicd` runs, with a separate mutable main entry, source branch/SHA, workflow completion metadata, run links, and exact OCI probing on selection.
+- [x] 2.8 Add a development catalog backed by recent successful manual `Create dev release` runs, with a separate mutable main entry discovered from `cicd` pushes, source branch/SHA, workflow completion metadata, run links, and exact OCI probing on selection.
 
 ## 3. Development artifact publication
 
-- [x] 3.1 Document and expose the existing authorized `cicd` manual dispatch for a selected feature branch or tag ref, resolving and recording the exact full source SHA.
-- [x] 3.2 Require lint, unit, and e2e success for manually dispatched publication; remove the current feature-branch e2e skip and prevent publication/handoff when a required gate fails.
+- [x] 3.1 Add and document the authorized `Create dev release` manual dispatch for a selected feature branch or tag ref, resolving and recording the exact full source SHA without a publish toggle.
+- [x] 3.2 Require lint and unit success for manually dispatched publication, run e2e only when selected, and prevent publication/handoff when an enabled required gate fails.
 - [x] 3.3 Publish manager, launcher, clabverter, clicker chart, and c9s chart as `0.0.0-<short-sha>`, with c9s chart values pinned to matching runtime image tags.
 - [x] 3.4 Embed the full source SHA in custom chart metadata and add post-push probes for the exact chart plus linux/amd64 and linux/arm64 manager/launcher manifests.
 - [x] 3.5 Add an exact unpublished-version KinD install smoke and write the full SHA, artifacts, `make install`, and `make try-c9s` handoff commands to the successful workflow summary.
 - [x] 3.6 Change main chart `0.0.0` packaging to embed the full main SHA and pin manager/launcher to immutable `0.0.0-<short-sha>` images while retaining `dev-latest` only as a development alias.
-- [x] 3.7 Add workflow-level checks for selected-ref identity, e2e publication blocking, exact custom artifacts, source metadata, main image pinning, artifact-probe failure, and handoff output.
+- [x] 3.7 Add workflow-level checks for selected-ref identity, optional e2e publication blocking, exact custom artifacts, source metadata, main image pinning, artifact-probe failure, and handoff output.
 
 ## 4. Shared context and artifact preflight
 

--- a/openspec/changes/installation/tasks.md
+++ b/openspec/changes/installation/tasks.md
@@ -31,7 +31,7 @@
 - [x] 4.1 Add shared install variables for context, namespace, Helm release, OCI chart, timeout, source selection, local transport, and registry while preserving compatible existing overrides.
 - [x] 4.2 Implement context capture and bounded existence, reachability, authentication, node-discovery, and required-permission checks that run before Helm and pass the captured context to every command.
 - [x] 4.3 Probe every stable, main, or unpublished selection with `helm show chart --version <exact>` and report an unavailable artifact without mutating the cluster.
-- [x] 4.4 Validate full source revision metadata and exact manager/launcher image pins for main and unpublished charts.
+- [x] 4.4 Resolve manager/launcher image references from selected chart values without requiring source-revision metadata during `make install`.
 - [x] 4.5 Inspect the selected chart CRDs to derive its c9s API group and inspect the cluster for installed legacy and `c9s.run` CRDs.
 - [x] 4.6 Block cross-group installation before Helm with the destructive `make uninstall-c9s` warning, while allowing same-group reinstall and version changes.
 - [ ] 4.7 Add focused preflight checks for no context, unknown context, stale or unreachable API endpoint, unauthenticated context, missing permissions, missing OCI version, invalid development metadata, and both API-group mismatch directions.


### PR DESCRIPTION
Refactor existing-cluster install orchestration into hack/c9s_install.py. Scope dirty worktree identity to Docker image inputs for reproducible local build tags. Build local images with docker buildx --load and reuse cached images on repeat installs unless C9S_LOCAL_REBUILD=1. Update CI and docs to match the new local image identity and install flow.