### PR TITLE
proper lab cleanup

### DIFF
--- a/launcher/containerlab.go
+++ b/launcher/containerlab.go
@@ -10,10 +10,13 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
+	"strings"
 
 	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
 	claberneteserrors "github.com/clabernetes/clabernetes/errors"
 	clabernetesutil "github.com/clabernetes/clabernetes/util"
+	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
 )
 
 const (
@@ -136,29 +139,100 @@ func (c *clabernetes) installContainerlabVersion(version string) error {
 	return extractContainerlabBin(inTarFile)
 }
 
-func (c *clabernetes) destroyContainerlab() {
-	c.logger.Debug("destroying any existing containerlab topology before deploy...")
-
-	cmd := exec.CommandContext(
-		c.ctx,
-		"containerlab",
-		"destroy",
-		"-t",
-		"topo.clab.yaml",
-		"--cleanup",
-	)
-
-	cmd.Stdout = c.containerlabLogger
-	cmd.Stderr = c.containerlabLogger
-
-	err := cmd.Run()
+// topologyHostInterfaces returns the sanitized names of all "host" link endpoints defined in the
+// given topology -- these are the interfaces containerlab will create in the pod (launcher)
+// network namespace when deploying the topology.
+func topologyHostInterfaces(rawTopology string) ([]string, error) {
+	containerlabConfig, _, err := clabernetesutilcontainerlab.LoadContainerlabConfig(rawTopology)
 	if err != nil {
-		// not fatal — topology may not exist on first run
-		c.logger.Debugf("containerlab destroy returned (expected on first run): %s", err)
+		return nil, err
+	}
+
+	if containerlabConfig.Topology == nil {
+		return nil, nil
+	}
+
+	var interfaceNames []string
+
+	for _, link := range containerlabConfig.Topology.Links {
+		for _, endpoint := range link.Endpoints {
+			nodeName, interfaceName, found := strings.Cut(endpoint, ":")
+			if !found || nodeName != clabernetesconstants.HostKeyword {
+				continue
+			}
+
+			if slices.Contains([]string{"lo", "eth0", "docker0"}, interfaceName) {
+				// never touch the pod's own plumbing regardless of what the topology says
+				continue
+			}
+
+			// containerlab replaces "/" with "-" when creating the host side interface, so the
+			// interface that can exist in our network namespace is the sanitized name
+			interfaceNames = append(
+				interfaceNames,
+				strings.ReplaceAll(interfaceName, "/", "-"),
+			)
+		}
+	}
+
+	return interfaceNames, nil
+}
+
+// removeStaleHostInterfaces removes any topology defined "host" interfaces left over from a
+// previous partially failed deploy. the pod network namespace belongs to the pod sandbox and so
+// outlives launcher container restarts -- a deploy that fails mid link creation can strand veth
+// ends in the namespace, causing all subsequent deploys to fail with "Interface host:<intf> is
+// defined via topology but already exists" until the interfaces (or the whole pod) are removed.
+func (c *clabernetes) removeStaleHostInterfaces() {
+	rawTopology, err := os.ReadFile("topo.clab.yaml")
+	if err != nil {
+		c.logger.Warnf("failed reading topology file to check for stale interfaces, err: %s", err)
+
+		return
+	}
+
+	interfaceNames, err := topologyHostInterfaces(string(rawTopology))
+	if err != nil {
+		c.logger.Warnf("failed parsing topology file to check for stale interfaces, err: %s", err)
+
+		return
+	}
+
+	for _, interfaceName := range interfaceNames {
+		checkCmd := exec.CommandContext( //nolint:gosec
+			c.ctx, "ip", "link", "show", "dev", interfaceName,
+		)
+
+		if checkCmd.Run() != nil {
+			// interface does not exist, nothing to clean up -- this is the normal case
+			continue
+		}
+
+		c.logger.Warnf(
+			"interface %q already exists in the pod network namespace, it was likely stranded"+
+				" by a previously failed deploy, removing it so deploy can proceed...",
+			interfaceName,
+		)
+
+		deleteCmd := exec.CommandContext( //nolint:gosec
+			c.ctx, "ip", "link", "delete", "dev", interfaceName,
+		)
+
+		output, err := deleteCmd.CombinedOutput()
+		if err != nil {
+			c.logger.Warnf(
+				"failed removing interface %q, deploy will likely fail, err: %s, output: %s",
+				interfaceName,
+				err,
+				string(output),
+			)
+		}
 	}
 }
 
 func (c *clabernetes) runContainerlab() error {
+	c.removeStaleHostInterfaces()
+
 	containerlabLogFile, err := os.Create("containerlab.log")
 	if err != nil {
 		return err
@@ -173,12 +247,6 @@ func (c *clabernetes) runContainerlab() error {
 	}
 
 	if !(os.Getenv(clabernetesconstants.LauncherContainerlabPersist) == clabernetesconstants.True) {
-		// When k8 redeploys nodes due to node crash or any other reason, host side interface is
-		// not cleaned up so we have to manually destroy the lab otherwise we will keep getting
-		// following error in a loop:
-		// containerlab | Interface host:<intf> is defined via topology but already exists: <nil>
-		c.destroyContainerlab()
-
 		args = append(args, "--reconfigure")
 	}
 

--- a/launcher/containerlab.go
+++ b/launcher/containerlab.go
@@ -139,7 +139,7 @@ func (c *clabernetes) installContainerlabVersion(version string) error {
 func (c *clabernetes) destroyContainerlab() {
 	c.logger.Debug("destroying any existing containerlab topology before deploy...")
 
-	cmd := exec.CommandContext( //nolint:gosec
+	cmd := exec.CommandContext(
 		c.ctx,
 		"containerlab",
 		"destroy",
@@ -151,7 +151,8 @@ func (c *clabernetes) destroyContainerlab() {
 	cmd.Stdout = c.containerlabLogger
 	cmd.Stderr = c.containerlabLogger
 
-	if err := cmd.Run(); err != nil {
+	err := cmd.Run()
+	if err != nil {
 		// not fatal — topology may not exist on first run
 		c.logger.Debugf("containerlab destroy returned (expected on first run): %s", err)
 	}
@@ -172,10 +173,12 @@ func (c *clabernetes) runContainerlab() error {
 	}
 
 	if !(os.Getenv(clabernetesconstants.LauncherContainerlabPersist) == clabernetesconstants.True) {
-		// when k8 redeploys nodes when node crashes or due to any other reason, host side interface
-		// is not cleaned up so we have to manually restroy the lab getting following error in a loop
-		// containerlab |   Interface host:<intf> is defined via topology but already exists: <nil>
+		// When k8 redeploys nodes due to node crash or any other reason, host side interface is
+		// not cleaned up so we have to manually destroy the lab otherwise we will keep getting
+		// following error in a loop:
+		// containerlab | Interface host:<intf> is defined via topology but already exists: <nil>
 		c.destroyContainerlab()
+
 		args = append(args, "--reconfigure")
 	}
 

--- a/launcher/containerlab.go
+++ b/launcher/containerlab.go
@@ -136,6 +136,27 @@ func (c *clabernetes) installContainerlabVersion(version string) error {
 	return extractContainerlabBin(inTarFile)
 }
 
+func (c *clabernetes) destroyContainerlab() {
+	c.logger.Debug("destroying any existing containerlab topology before deploy...")
+
+	cmd := exec.CommandContext( //nolint:gosec
+		c.ctx,
+		"containerlab",
+		"destroy",
+		"-t",
+		"topo.clab.yaml",
+		"--cleanup",
+	)
+
+	cmd.Stdout = c.containerlabLogger
+	cmd.Stderr = c.containerlabLogger
+
+	if err := cmd.Run(); err != nil {
+		// not fatal — topology may not exist on first run
+		c.logger.Debugf("containerlab destroy returned (expected on first run): %s", err)
+	}
+}
+
 func (c *clabernetes) runContainerlab() error {
 	containerlabLogFile, err := os.Create("containerlab.log")
 	if err != nil {
@@ -151,6 +172,10 @@ func (c *clabernetes) runContainerlab() error {
 	}
 
 	if !(os.Getenv(clabernetesconstants.LauncherContainerlabPersist) == clabernetesconstants.True) {
+		// when k8 redeploys nodes when node crashes or due to any other reason, host side interface
+		// is not cleaned up so we have to manually restroy the lab getting following error in a loop
+		// containerlab |   Interface host:<intf> is defined via topology but already exists: <nil>
+		c.destroyContainerlab()
 		args = append(args, "--reconfigure")
 	}
 

--- a/launcher/containerlab_test.go
+++ b/launcher/containerlab_test.go
@@ -1,6 +1,9 @@
 package launcher //nolint:testpackage // tests cover unexported release archive helpers
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestContainerlabReleaseTarName(t *testing.T) {
 	t.Parallel()
@@ -50,6 +53,84 @@ func TestContainerlabReleaseTarName(t *testing.T) {
 			}
 
 			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestTopologyHostInterfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rawTopology string
+		expected    []string
+	}{
+		{
+			name: "simple",
+			rawTopology: `
+name: clabernetes-se1
+topology:
+  nodes:
+    se1:
+      kind: arrcus_arcos
+  links:
+    - endpoints: ["se1:eth1", "host:se1-eth1"]
+    - endpoints: ["se1:eth2", "host:se1-eth2"]
+`,
+			expected: []string{"se1-eth1", "se1-eth2"},
+		},
+		{
+			name: "sanitizes-slashes",
+			rawTopology: `
+name: clabernetes-sr1
+topology:
+  nodes:
+    sr1:
+      kind: nokia_sros
+  links:
+    - endpoints: ["sr1:1/1/c1/1", "host:sr1-1/1/c1/1"]
+`,
+			expected: []string{"sr1-1-1-c1-1"},
+		},
+		{
+			name: "skips-protected-interfaces",
+			rawTopology: `
+name: clabernetes-se1
+topology:
+  nodes:
+    se1:
+      kind: arrcus_arcos
+  links:
+    - endpoints: ["se1:eth1", "host:eth0"]
+    - endpoints: ["se1:eth2", "host:se1-eth2"]
+`,
+			expected: []string{"se1-eth2"},
+		},
+		{
+			name: "no-links",
+			rawTopology: `
+name: clabernetes-se1
+topology:
+  nodes:
+    se1:
+      kind: arrcus_arcos
+`,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := topologyHostInterfaces(tt.rawTopology)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.expected) {
 				t.Fatalf("expected %q, got %q", tt.expected, got)
 			}
 		})


### PR DESCRIPTION
## Problem

When a launcher pod's container is restarted in place (failed deploy attempt → `os.Exit` + `RestartPolicy: Always`, OOM kill, etc.), every subsequent containerlab deploy can fail in a permanent crash loop with:

```
containerlab | Interface host:<node>-<iface> is defined via topology but already exists: <nil>
```

The only recovery is deleting the pod itself.

## Root cause

- clabernetes sub-topologies express every inter-node link as a veth to the containerlab `host` node, e.g. `["se1:eth2", "host:se1-eth2"]`. Inside a launcher, the "host" network namespace is the **pod network namespace**.
- The pod netns is owned by the pod sandbox (pause container), so it **survives launcher container restarts** — kubelet restarts only the launcher container and re-attaches it to the same sandbox. Only pod deletion recreates the netns.
- containerlab creates both veth ends in the current (pod) netns first, then moves/renames each end into its endpoint namespace. A deploy that dies inside that window (image pull failure, VM node startup timeout, deploy timeout) strands the veth pair in the pod netns, attached to no container.
- Interfaces properly moved into node containers cannot leak: killing the launcher container kills the nested lab containers, destroying their netns and both veth ends with it. Only interfaces sitting directly in the pod netns persist.
- On the next attempt the nested dockerd starts with empty state, so neither `containerlab destroy` nor the destroy phase of `deploy --reconfigure` can enumerate the previous lab — the stranded interfaces are invisible to containerlab, and its pre-deploy endpoint verification fails on every retry until the pod is deleted.

## Fix

Before invoking `containerlab deploy`, the launcher now:

1. parses `topo.clab.yaml` and collects all `host:` link endpoints
2. applies containerlab's interface name sanitization (`/` → `-`, matching what actually gets created in the netns)
3. checks each via `ip link show` and removes leftovers via `ip link delete`, with a WARN log per removed interface (`lo`/`eth0`/`docker0` are guarded and never touched)

Since interfaces from a healthy previous run cannot survive a container restart, any interface matching a topology host endpoint at startup is stranded by construction and safe to remove. Failed deploys become self-healing on the next restart — no manual pod deletion required.

Unit tests cover the endpoint extraction: basic case, `/` sanitization (SR OS style `1/1/c1/1` names), protected interface guard, and topologies without links.
