### PR TITLE
Drop trailing slash for cf workers, added redirects and allow refresh of the pages

### DIFF
--- a/.cursor/skills/test-fumadocs-wrangler/SKILL.md
+++ b/.cursor/skills/test-fumadocs-wrangler/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: test-fumadocs-wrangler
+description: Builds and validates the Fumadocs React Router static site through Wrangler with headless browser checks. Use when testing production-like docs behavior, redirects, direct loads, refreshes, Cloudflare SPA fallback, or temporary Wrangler previews without committing.
+---
+
+# Test Fumadocs with Wrangler
+
+Use `scripts/test.sh` for production-like docs tests. It:
+
+1. Builds `docs-site`.
+2. Installs Wrangler, Playwright, npm cache, and Chromium only under `mktemp`.
+3. Copies Wrangler configuration and links build assets inside that temporary directory.
+4. Runs `wrangler dev` from the temporary directory.
+5. Checks direct loads, refreshes, redirects, console errors, page errors, and failed requests in Chromium.
+6. Stops Wrangler and deletes the temporary directory on success, failure, or interruption.
+
+## Run
+
+Pass paths as arguments. Use quoted `source=>destination` entries for redirects:
+
+```bash
+bash .cursor/skills/test-fumadocs-wrangler/scripts/test.sh \
+  /docs/quickstart \
+  /docs/release-notes/0.7 \
+  '/docs/release-notes/0.7.0=>/docs/release-notes/0.7' \
+  '/docs/release-notes/0.7.0/=>/docs/release-notes/0.7'
+```
+
+With no arguments, the script checks `/docs`.
+
+To upload the passing build to an unauthenticated temporary Cloudflare account:
+
+```bash
+DEPLOY_TEMPORARY=1 bash .cursor/skills/test-fumadocs-wrangler/scripts/test.sh /docs
+```
+
+Temporary deployments can show Cloudflare human verification to automated browsers. Treat local Wrangler + Chromium as the automated pass/fail result; report the temporary URL for manual inspection.
+
+## Rules
+
+- Never install testing tools into the repository or change `package.json`/lockfiles.
+- Do not use `pnpm dlx`, global installs, or repository-local Wrangler state.
+- Do not create `.wrangler/` in the repository.
+- If project dependencies are missing, stop and report that `docs-site/node_modules` must be installed separately.
+- Run local checks before any external upload.
+- Only deploy when the user requests a temporary preview.
+- Do not update production or an existing preview alias unless the user explicitly requests it and credentials are already available.
+- After testing, confirm no Wrangler process remains and no temporary files were added to Git.

--- a/.cursor/skills/test-fumadocs-wrangler/scripts/test.sh
+++ b/.cursor/skills/test-fumadocs-wrangler/scripts/test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCS_SITE="$REPO_ROOT/docs-site"
+PORT="${PORT:-8787}"
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_ROOT="$(mktemp -d "$TMP_BASE/fumadocs-wrangler-test.XXXXXX")"
+TOOLS_DIR="$TMP_ROOT/tools"
+BROWSERS_DIR="$TMP_ROOT/browsers"
+WRANGLER_PID=""
+
+cleanup() {
+  if [[ -n "$WRANGLER_PID" ]] && kill -0 "$WRANGLER_PID" 2>/dev/null; then
+    kill "$WRANGLER_PID" 2>/dev/null || true
+    wait "$WRANGLER_PID" 2>/dev/null || true
+  fi
+
+  case "$TMP_ROOT" in
+    "$TMP_BASE"/fumadocs-wrangler-test.*)
+      rm -rf -- "$TMP_ROOT"
+      ;;
+    *)
+      printf 'Refusing to remove unexpected temporary path: %s\n' "$TMP_ROOT" >&2
+      ;;
+  esac
+}
+trap cleanup EXIT INT TERM
+
+if [[ ! -d "$DOCS_SITE/node_modules" ]]; then
+  printf 'docs-site/node_modules is missing; install project dependencies separately.\n' >&2
+  exit 1
+fi
+
+if (($# == 0)); then
+  SPECS=("/docs")
+else
+  SPECS=("$@")
+fi
+
+printf 'Building docs...\n'
+pnpm --dir "$DOCS_SITE" run build
+
+printf 'Installing test tools under %s...\n' "$TMP_ROOT"
+mkdir -p "$TOOLS_DIR" "$BROWSERS_DIR" "$TMP_ROOT/docs-site/build"
+NPM_CONFIG_CACHE="$TMP_ROOT/npm-cache" \
+  npm install --prefix "$TOOLS_DIR" --no-audit --no-fund --silent \
+  playwright@latest wrangler@4
+
+PLAYWRIGHT="$TOOLS_DIR/node_modules/.bin/playwright"
+WRANGLER="$TOOLS_DIR/node_modules/.bin/wrangler"
+PLAYWRIGHT_BROWSERS_PATH="$BROWSERS_DIR" "$PLAYWRIGHT" install chromium
+
+cp "$REPO_ROOT/wrangler.toml" "$TMP_ROOT/wrangler.toml"
+ln -s "$DOCS_SITE/build/client" "$TMP_ROOT/docs-site/build/client"
+
+export XDG_CONFIG_HOME="$TMP_ROOT/xdg-config"
+export WRANGLER_HOME="$TMP_ROOT/wrangler-home"
+export WRANGLER_SEND_METRICS=false
+export PLAYWRIGHT_BROWSERS_PATH="$BROWSERS_DIR"
+
+(
+  cd "$TMP_ROOT"
+  "$WRANGLER" dev \
+    --config "$TMP_ROOT/wrangler.toml" \
+    --port "$PORT" \
+    --persist-to "$TMP_ROOT/wrangler-state"
+) >"$TMP_ROOT/wrangler.log" 2>&1 &
+WRANGLER_PID=$!
+
+BASE_URL="http://127.0.0.1:$PORT"
+ready=false
+for _ in {1..120}; do
+  if curl --fail --silent --output /dev/null "$BASE_URL/"; then
+    ready=true
+    break
+  fi
+  if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ "$ready" != true ]]; then
+  printf 'Wrangler failed to start:\n' >&2
+  while IFS= read -r line; do
+    printf '%s\n' "$line" >&2
+  done <"$TMP_ROOT/wrangler.log"
+  exit 1
+fi
+
+TEST_SPECS_JSON="$(
+  node -e 'process.stdout.write(JSON.stringify(process.argv.slice(1)))' "${SPECS[@]}"
+)"
+export BASE_URL TEST_SPECS_JSON TOOLS_DIR
+
+node <<'NODE'
+const { chromium } = require(
+  `${process.env.TOOLS_DIR}/node_modules/playwright`,
+);
+
+const baseUrl = process.env.BASE_URL;
+const specs = JSON.parse(process.env.TEST_SPECS_JSON);
+
+async function verify(page, expectedPath, errors, phase) {
+  await page.waitForLoadState('networkidle').catch(() => {});
+  await page.waitForTimeout(250);
+
+  const actualPath = new URL(page.url()).pathname;
+  const body = await page.locator('body').innerText();
+  const problems = [...errors];
+
+  if (actualPath !== expectedPath) {
+    problems.push(`expected path ${expectedPath}, got ${actualPath}`);
+  }
+  if (!body.trim()) {
+    problems.push('page body is empty');
+  }
+  if (
+    body.includes('Something went wrong') ||
+    body.includes('Documentation page not found')
+  ) {
+    problems.push('application error page rendered');
+  }
+
+  if (problems.length > 0) {
+    throw new Error(`${phase} failed:\n  ${problems.join('\n  ')}`);
+  }
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  let failed = false;
+
+  for (const spec of specs) {
+    const separator = spec.indexOf('=>');
+    const source =
+      separator === -1 ? spec : spec.slice(0, separator);
+    const expected =
+      separator === -1 ? source : spec.slice(separator + 2);
+    const page = await browser.newPage();
+    const errors = [];
+
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        errors.push(`console: ${message.text()}`);
+      }
+    });
+    page.on('pageerror', (error) => {
+      errors.push(`page: ${error.message}`);
+    });
+    page.on('requestfailed', (request) => {
+      errors.push(
+        `request: ${request.url()} (${request.failure()?.errorText ?? 'failed'})`,
+      );
+    });
+
+    try {
+      await page.goto(`${baseUrl}${source}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      if (source !== expected) {
+        await page.waitForURL((url) => url.pathname === expected);
+      }
+      await verify(page, expected, errors, `direct load ${spec}`);
+
+      errors.length = 0;
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await verify(page, expected, errors, `refresh ${spec}`);
+
+      console.log(`PASS ${spec}`);
+    } catch (error) {
+      failed = true;
+      console.error(`FAIL ${spec}\n${error.stack ?? error}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  await browser.close();
+  if (failed) process.exit(1);
+})().catch((error) => {
+  console.error(error.stack ?? error);
+  process.exit(1);
+});
+NODE
+
+if [[ "${DEPLOY_TEMPORARY:-0}" == "1" ]]; then
+  printf 'Uploading passing build to a temporary Cloudflare account...\n'
+  (
+    cd "$TMP_ROOT"
+    "$WRANGLER" deploy \
+      --temporary \
+      --config "$TMP_ROOT/wrangler.toml"
+  )
+fi

--- a/docs-site/app/lib/docs-redirects.ts
+++ b/docs-site/app/lib/docs-redirects.ts
@@ -1,0 +1,14 @@
+/** Legacy docs URLs that should redirect to their replacement. */
+export const docsPathRedirects: Record<string, string> = {
+  '/docs/release-notes/0.7.0': '/docs/release-notes/0.7',
+};
+
+export function normalizePathname(pathname: string): string {
+  return pathname.endsWith('/') && pathname !== '/'
+    ? pathname.slice(0, -1)
+    : pathname;
+}
+
+export function docsRedirect(pathname: string): string | undefined {
+  return docsPathRedirects[normalizePathname(pathname)];
+}

--- a/docs-site/app/root.tsx
+++ b/docs-site/app/root.tsx
@@ -4,11 +4,9 @@ import {
   Links,
   Meta,
   Outlet,
-  redirect,
   Scripts,
   ScrollRestoration,
 } from 'react-router';
-import { docsRedirect } from '@/lib/docs-redirects';
 import c9sLogo from '@/assets/c9s-logo-clean.png';
 import StaticSearchDialog from '@/components/static-search';
 import { UnderDevelopmentBanner } from '@/components/under-development-banner';
@@ -19,18 +17,6 @@ export const links: Route.LinksFunction = () => [
   { rel: 'icon', href: c9sLogo, type: 'image/png' },
   { rel: 'apple-touch-icon', href: c9sLogo, type: 'image/png' },
 ];
-
-// Cloudflare SPA fallback serves home index.html for unknown paths, so the docs
-// route loader never runs. Redirect legacy URLs from the browser path on hydrate.
-export async function clientLoader() {
-  const target = docsRedirect(window.location.pathname);
-  if (target) {
-    throw redirect(target, { status: 308 });
-  }
-  return null;
-}
-
-clientLoader.hydrate = true;
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/docs-site/app/root.tsx
+++ b/docs-site/app/root.tsx
@@ -4,9 +4,11 @@ import {
   Links,
   Meta,
   Outlet,
+  redirect,
   Scripts,
   ScrollRestoration,
 } from 'react-router';
+import { docsRedirect } from '@/lib/docs-redirects';
 import c9sLogo from '@/assets/c9s-logo-clean.png';
 import StaticSearchDialog from '@/components/static-search';
 import { UnderDevelopmentBanner } from '@/components/under-development-banner';
@@ -17,6 +19,18 @@ export const links: Route.LinksFunction = () => [
   { rel: 'icon', href: c9sLogo, type: 'image/png' },
   { rel: 'apple-touch-icon', href: c9sLogo, type: 'image/png' },
 ];
+
+// Cloudflare SPA fallback serves home index.html for unknown paths, so the docs
+// route loader never runs. Redirect legacy URLs from the browser path on hydrate.
+export async function clientLoader() {
+  const target = docsRedirect(window.location.pathname);
+  if (target) {
+    throw redirect(target, { status: 308 });
+  }
+  return null;
+}
+
+clientLoader.hydrate = true;
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useMemo, useState } from 'react';
+import { use, useMemo } from 'react';
 import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import {
@@ -43,11 +43,13 @@ export async function loader({ params }: Route.LoaderArgs) {
   };
 }
 
-function MdxPageContent({
-  page,
-}: {
-  page: NonNullable<ReturnType<typeof docs.getPage>>;
-}) {
+function Content({ path }: { path: string }) {
+  const page = docs.getPage(path);
+
+  if (!page) {
+    throw new Error(`Unknown documentation page: ${path}`);
+  }
+
   const { toc } = use(page.load());
   const MDX = page.body;
 
@@ -64,32 +66,6 @@ function MdxPageContent({
       </DocsBody>
     </DocsPage>
   );
-}
-
-function Content({ path }: { path: string }) {
-  const page = docs.getPage(path);
-
-  if (!page) {
-    throw new Error(`Unknown documentation page: ${path}`);
-  }
-
-  const [preloaded, setPreloaded] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    void page.preload().then(() => {
-      if (active) setPreloaded(true);
-    });
-    return () => {
-      active = false;
-    };
-  }, [page]);
-
-  if (!preloaded) {
-    return null;
-  }
-
-  return <MdxPageContent page={page} />;
 }
 
 export default function DocumentationPage({

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -42,6 +42,16 @@ export async function loader({ params }: Route.LoaderArgs) {
   };
 }
 
+export async function clientLoader({
+  serverLoader,
+}: Route.ClientLoaderArgs) {
+  const data = await serverLoader();
+  await docs.getPage(data.path)?.preload();
+  return data;
+}
+
+clientLoader.hydrate = true;
+
 function Content({ path }: { path: string }) {
   const page = docs.getPage(path);
 

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -10,6 +10,7 @@ import {
 import { redirect } from 'react-router';
 import { getMDXComponents } from '@/components/mdx';
 import { getDocsTabs } from '@/lib/docs-tabs';
+import { docsRedirect } from '@/lib/docs-redirects';
 import { baseOptions } from '@/lib/layout.shared';
 import { docs, source } from '@/lib/source';
 import type { Route } from './+types/docs';
@@ -21,9 +22,9 @@ export async function loader({ params }: Route.LoaderArgs) {
   const slug = params['*'] ?? '';
 
   // REDIRECTS SHOULD BE HANDLED HERE
-  // Redirect legacy release notes path to the new one.
-  if (slug === 'release-notes/0.7.0') {
-    throw redirect('/docs/release-notes/0.7', { status: 308 });
+  const redirectTarget = docsRedirect(`/docs/${slug.replace(/\/$/, '')}`);
+  if (redirectTarget) {
+    throw redirect(redirectTarget, { status: 308 });
   }
   // END REDIRECTS
 

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -1,4 +1,4 @@
-import { Suspense, use, useMemo } from 'react';
+import { use, useEffect, useMemo, useState } from 'react';
 import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import {
@@ -73,11 +73,23 @@ function Content({ path }: { path: string }) {
     throw new Error(`Unknown documentation page: ${path}`);
   }
 
-  return (
-    <Suspense fallback={null}>
-      <MdxPageContent page={page} />
-    </Suspense>
-  );
+  const [preloaded, setPreloaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void page.preload().then(() => {
+      if (active) setPreloaded(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [page]);
+
+  if (!preloaded) {
+    return null;
+  }
+
+  return <MdxPageContent page={page} />;
 }
 
 export default function DocumentationPage({

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -7,6 +7,7 @@ import {
   DocsPage,
   DocsTitle,
 } from 'fumadocs-ui/layouts/docs/page';
+import { redirect } from 'react-router';
 import { getMDXComponents } from '@/components/mdx';
 import { getDocsTabs } from '@/lib/docs-tabs';
 import { baseOptions } from '@/lib/layout.shared';
@@ -14,7 +15,19 @@ import { docs, source } from '@/lib/source';
 import type { Route } from './+types/docs';
 
 export async function loader({ params }: Route.LoaderArgs) {
-  const slugs = params['*']?.split('/').filter(Boolean) ?? [];
+  // params['*'] contains the full catch-all path, such as
+  // "release-notes/0.7.0"; keep it whole for legacy redirects, then split it
+  // by "/" into the slug segments expected by the Fumadocs source.
+  const slug = params['*'] ?? '';
+
+  // REDIRECTS SHOULD BE HANDLED HERE
+  // Redirect legacy release notes path to the new one.
+  if (slug === 'release-notes/0.7.0') {
+    throw redirect('/docs/release-notes/0.7', { status: 308 });
+  }
+  // END REDIRECTS
+
+  const slugs = slug.split('/').filter(Boolean);
   const page = source.getPage(slugs);
 
   if (!page) {

--- a/docs-site/app/routes/docs.tsx
+++ b/docs-site/app/routes/docs.tsx
@@ -1,4 +1,4 @@
-import { use, useMemo } from 'react';
+import { Suspense, use, useMemo } from 'react';
 import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import {
@@ -43,23 +43,11 @@ export async function loader({ params }: Route.LoaderArgs) {
   };
 }
 
-export async function clientLoader({
-  serverLoader,
-}: Route.ClientLoaderArgs) {
-  const data = await serverLoader();
-  await docs.getPage(data.path)?.preload();
-  return data;
-}
-
-clientLoader.hydrate = true;
-
-function Content({ path }: { path: string }) {
-  const page = docs.getPage(path);
-
-  if (!page) {
-    throw new Error(`Unknown documentation page: ${path}`);
-  }
-
+function MdxPageContent({
+  page,
+}: {
+  page: NonNullable<ReturnType<typeof docs.getPage>>;
+}) {
   const { toc } = use(page.load());
   const MDX = page.body;
 
@@ -75,6 +63,20 @@ function Content({ path }: { path: string }) {
         <MDX components={getMDXComponents()} />
       </DocsBody>
     </DocsPage>
+  );
+}
+
+function Content({ path }: { path: string }) {
+  const page = docs.getPage(path);
+
+  if (!page) {
+    throw new Error(`Unknown documentation page: ${path}`);
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <MdxPageContent page={page} />
+    </Suspense>
   );
 }
 

--- a/docs-site/react-router.config.ts
+++ b/docs-site/react-router.config.ts
@@ -2,6 +2,7 @@ import type { Config } from '@react-router/dev/config';
 import { createGetUrl, getSlugs } from 'fumadocs-core/source';
 import { glob } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { docsPathRedirects } from './app/lib/docs-redirects';
 
 const docsDirectory = fileURLToPath(new URL('../docs', import.meta.url));
 const getDocsUrl = createGetUrl('/docs');
@@ -28,6 +29,10 @@ export default {
       for await (const entry of glob(pattern, { cwd: docsDirectory })) {
         paths.add(getDocsUrl(getSlugs(entry)));
       }
+    }
+
+    for (const legacyPath of Object.keys(docsPathRedirects)) {
+      paths.add(legacyPath);
     }
 
     return [...paths];

--- a/docs-site/react-router.config.ts
+++ b/docs-site/react-router.config.ts
@@ -13,7 +13,6 @@ export default {
     v8_middleware: true,
     v8_passThroughRequests: true,
     v8_splitRouteModules: true,
-    v8_trailingSlashAwareDataRequests: true,
     v8_viteEnvironmentApi: true,
   },
   routeDiscovery: {

--- a/docs/release-notes/0.7.mdx
+++ b/docs/release-notes/0.7.mdx
@@ -147,3 +147,10 @@ The project repository and published artifacts have moved from the `srl-labs` or
 - Manager and launcher Docker build contexts were reduced and release image builds were
   streamlined, including corrected certificate ownership for OpenShift-compatible launcher images.
 - GitHub Actions `checkout` and `setup-go` were updated to version 7.
+
+## Patches
+
+### 0.7.1
+
+- Updated `x/crypto` and `x/net` dependencies to fix security vulnerabilities.
+- Fixed cloudflare redirects for trailing slashes.

--- a/docs/release-notes/0.7.mdx
+++ b/docs/release-notes/0.7.mdx
@@ -1,5 +1,5 @@
 ---
-title: 0.7.0
+title: "0.7"
 ---
 
 2026-08-11 · [Full Changelog](https://github.com/clabernetes/clabernetes/compare/v0.6.0...v0.7.0)

--- a/docs/release-notes/meta.yaml
+++ b/docs/release-notes/meta.yaml
@@ -1,4 +1,4 @@
 title: Release Notes
 icon: ScrollText
 pages:
-  - 0.7.0
+  - "0.7"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,3 +5,4 @@ preview_urls = true
 [assets]
 directory = "./docs-site/build/client"
 html_handling = "drop-trailing-slash"
+not_found_handling = "single-page-application"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,4 @@ preview_urls = true
 
 [assets]
 directory = "./docs-site/build/client"
+html_handling = "drop-trailing-slash"


### PR DESCRIPTION
## Documentation preview

### What this PR changes

- Renames the release note article from `0.7.0.mdx` to `0.7.mdx` and updates the release-notes navigation.
- Preserves saved links from `/docs/release-notes/0.7.0` and `/docs/release-notes/0.7.0/` by redirecting them to `/docs/release-notes/0.7`.
- Centralizes legacy URL mappings and uses them for both the docs route and static prerendering.
- Configures Cloudflare Workers Static Assets with SPA fallback for direct visits to paths without a matching file.
- Removes React Router `v8_trailingSlashAwareDataRequests`, which caused `No result found for routeId "routes/docs"` during static SPA hydration.
- Adds a reusable Cursor skill that builds the site, runs it through Wrangler, checks direct loads, refreshes, redirects, browser errors, and cleans all temporary tools and state afterward.

### Validation

The local Wrangler + Chromium loop passes:

- `/docs/quickstart`
- `/docs/release-notes/0.7`
- `/docs/release-notes/0.7.0` → `/docs/release-notes/0.7`
- `/docs/release-notes/0.7.0/` → `/docs/release-notes/0.7`