### PR TITLE
Improve generic node readiness reporting

### DIFF
--- a/apis/v1alpha1/topologyspec.go
+++ b/apis/v1alpha1/topologyspec.go
@@ -229,12 +229,13 @@ type Scheduling struct {
 }
 
 // StatusProbes holds details about if the status probes are enabled and if so how they should be
-// handled.
+// handled. Enabled probes always require the nested container to be running and not paused,
+// restarting, or dead. If Docker exposes an image-defined healthcheck, it must also be healthy.
+// Configured TCP and SSH probes are additional requirements.
 type StatusProbes struct {
-	// Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes
-	// are enabled and the health condition fails due to configuring the node the cluster will
-	// restart the node. So, if you plan on being destructive with the node config (probably because
-	// you will have exec'd onto the node) then you may want to disable this!
+	// Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously
+	// started but later fails its readiness check remains running and is reported not ready. A Node
+	// that never passes its startup check is restarted after its startup allowance expires.
 	// +kubebuilder:default=true
 	// +optional
 	Enabled bool `json:"enabled"`
@@ -255,17 +256,14 @@ type StatusProbes struct {
 	ProbeConfiguration ProbeConfiguration `json:"probeConfiguration"`
 }
 
-// ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If
-// both style probes are configured, both will be used and both must succeed in order to report
-// healthy.
+// ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a
+// Topology. If both styles are configured, both and the generic nested-container probe must succeed
+// in order to report healthy.
 type ProbeConfiguration struct {
 	// StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-	// to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-	// initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-	// delay as there must be time for c9s to (via whatever means) pull the image and load it into
-	// docker on the launcher and this can take a bit! Having this be bigger than you think you need
-	// is generally better since if the startup probe succeeds ever then the readiness probe takes
-	// over anyway.
+	// to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+	// c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+	// does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
 	// +optional
 	StartupSeconds int `json:"startupSeconds"`
 	// SSHProbeConfiguration defines an SSH probe.

--- a/assets/crd/c9s.run_launcherprofiles.yaml
+++ b/assets/crd/c9s.run_launcherprofiles.yaml
@@ -493,10 +493,9 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes
-                      are enabled and the health condition fails due to configuring the node the cluster will
-                      restart the node. So, if you plan on being destructive with the node config (probably because
-                      you will have exec'd onto the node) then you may want to disable this!
+                      Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously
+                      started but later fails its readiness check remains running and is reported not ready. A Node
+                      that never passes its startup check is restarted after its startup allowance expires.
                     type: boolean
                   excludedNodes:
                     description: |-
@@ -511,9 +510,9 @@ spec:
                   nodeProbeConfigurations:
                     additionalProperties:
                       description: |-
-                        ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If
-                        both style probes are configured, both will be used and both must succeed in order to report
-                        healthy.
+                        ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a
+                        Topology. If both styles are configured, both and the generic nested-container probe must succeed
+                        in order to report healthy.
                       properties:
                         sshProbeConfiguration:
                           description: SSHProbeConfiguration defines an SSH probe.
@@ -535,12 +534,9 @@ spec:
                         startupSeconds:
                           description: |-
                             StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                            to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                            initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                            delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                            docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                            is generally better since if the startup probe succeeds ever then the readiness probe takes
-                            over anyway.
+                            to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                            c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                            does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                           type: integer
                         tcpProbeConfiguration:
                           description: TCPProbeConfiguration defines a TCP probe.
@@ -585,12 +581,9 @@ spec:
                       startupSeconds:
                         description: |-
                           StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                          to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                          initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                          delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                          docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                          is generally better since if the startup probe succeeds ever then the readiness probe takes
-                          over anyway.
+                          to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                          c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                          does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                         type: integer
                       tcpProbeConfiguration:
                         description: TCPProbeConfiguration defines a TCP probe.

--- a/assets/crd/c9s.run_topologies.yaml
+++ b/assets/crd/c9s.run_topologies.yaml
@@ -683,10 +683,9 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes
-                      are enabled and the health condition fails due to configuring the node the cluster will
-                      restart the node. So, if you plan on being destructive with the node config (probably because
-                      you will have exec'd onto the node) then you may want to disable this!
+                      Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously
+                      started but later fails its readiness check remains running and is reported not ready. A Node
+                      that never passes its startup check is restarted after its startup allowance expires.
                     type: boolean
                   excludedNodes:
                     description: |-
@@ -701,9 +700,9 @@ spec:
                   nodeProbeConfigurations:
                     additionalProperties:
                       description: |-
-                        ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If
-                        both style probes are configured, both will be used and both must succeed in order to report
-                        healthy.
+                        ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a
+                        Topology. If both styles are configured, both and the generic nested-container probe must succeed
+                        in order to report healthy.
                       properties:
                         sshProbeConfiguration:
                           description: SSHProbeConfiguration defines an SSH probe.
@@ -725,12 +724,9 @@ spec:
                         startupSeconds:
                           description: |-
                             StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                            to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                            initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                            delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                            docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                            is generally better since if the startup probe succeeds ever then the readiness probe takes
-                            over anyway.
+                            to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                            c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                            does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                           type: integer
                         tcpProbeConfiguration:
                           description: TCPProbeConfiguration defines a TCP probe.
@@ -775,12 +771,9 @@ spec:
                       startupSeconds:
                         description: |-
                           StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                          to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                          initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                          delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                          docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                          is generally better since if the startup probe succeeds ever then the readiness probe takes
-                          over anyway.
+                          to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                          c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                          does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                         type: integer
                       tcpProbeConfiguration:
                         description: TCPProbeConfiguration defines a TCP probe.

--- a/charts/clabernetes/crds/c9s.run_launcherprofiles.yaml
+++ b/charts/clabernetes/crds/c9s.run_launcherprofiles.yaml
@@ -493,10 +493,9 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes
-                      are enabled and the health condition fails due to configuring the node the cluster will
-                      restart the node. So, if you plan on being destructive with the node config (probably because
-                      you will have exec'd onto the node) then you may want to disable this!
+                      Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously
+                      started but later fails its readiness check remains running and is reported not ready. A Node
+                      that never passes its startup check is restarted after its startup allowance expires.
                     type: boolean
                   excludedNodes:
                     description: |-
@@ -511,9 +510,9 @@ spec:
                   nodeProbeConfigurations:
                     additionalProperties:
                       description: |-
-                        ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If
-                        both style probes are configured, both will be used and both must succeed in order to report
-                        healthy.
+                        ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a
+                        Topology. If both styles are configured, both and the generic nested-container probe must succeed
+                        in order to report healthy.
                       properties:
                         sshProbeConfiguration:
                           description: SSHProbeConfiguration defines an SSH probe.
@@ -535,12 +534,9 @@ spec:
                         startupSeconds:
                           description: |-
                             StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                            to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                            initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                            delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                            docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                            is generally better since if the startup probe succeeds ever then the readiness probe takes
-                            over anyway.
+                            to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                            c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                            does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                           type: integer
                         tcpProbeConfiguration:
                           description: TCPProbeConfiguration defines a TCP probe.
@@ -585,12 +581,9 @@ spec:
                       startupSeconds:
                         description: |-
                           StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                          to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                          initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                          delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                          docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                          is generally better since if the startup probe succeeds ever then the readiness probe takes
-                          over anyway.
+                          to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                          c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                          does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                         type: integer
                       tcpProbeConfiguration:
                         description: TCPProbeConfiguration defines a TCP probe.

--- a/charts/clabernetes/crds/c9s.run_topologies.yaml
+++ b/charts/clabernetes/crds/c9s.run_topologies.yaml
@@ -683,10 +683,9 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes
-                      are enabled and the health condition fails due to configuring the node the cluster will
-                      restart the node. So, if you plan on being destructive with the node config (probably because
-                      you will have exec'd onto the node) then you may want to disable this!
+                      Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously
+                      started but later fails its readiness check remains running and is reported not ready. A Node
+                      that never passes its startup check is restarted after its startup allowance expires.
                     type: boolean
                   excludedNodes:
                     description: |-
@@ -701,9 +700,9 @@ spec:
                   nodeProbeConfigurations:
                     additionalProperties:
                       description: |-
-                        ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If
-                        both style probes are configured, both will be used and both must succeed in order to report
-                        healthy.
+                        ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a
+                        Topology. If both styles are configured, both and the generic nested-container probe must succeed
+                        in order to report healthy.
                       properties:
                         sshProbeConfiguration:
                           description: SSHProbeConfiguration defines an SSH probe.
@@ -725,12 +724,9 @@ spec:
                         startupSeconds:
                           description: |-
                             StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                            to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                            initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                            delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                            docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                            is generally better since if the startup probe succeeds ever then the readiness probe takes
-                            over anyway.
+                            to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                            c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                            does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                           type: integer
                         tcpProbeConfiguration:
                           description: TCPProbeConfiguration defines a TCP probe.
@@ -775,12 +771,9 @@ spec:
                       startupSeconds:
                         description: |-
                           StartupSeconds is the total amount of seconds to allow for the node to start. This defaults
-                          to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60
-                          initial delay configured, so technically the default is ~14-15 minutes. Be careful with this
-                          delay as there must be time for c9s to (via whatever means) pull the image and load it into
-                          docker on the launcher and this can take a bit! Having this be bigger than you think you need
-                          is generally better since if the startup probe succeeds ever then the readiness probe takes
-                          over anyway.
+                          to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for
+                          c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value
+                          does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.
                         type: integer
                       tcpProbeConfiguration:
                         description: TCPProbeConfiguration defines a TCP probe.

--- a/charts/clabernetes/templates/deployment.yaml
+++ b/charts/clabernetes/templates/deployment.yaml
@@ -139,6 +139,15 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: 10443
+              scheme: HTTPS
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
       {{- $tolerations := concat $.Values.globalTolerations $.Values.manager.deploymentTolerations }}
       {{- if $tolerations }}
       tolerations:

--- a/charts/clabernetes/tests/clicker_enabled/test-fixtures/golden/deployment.yaml
+++ b/charts/clabernetes/tests/clicker_enabled/test-fixtures/golden/deployment.yaml
@@ -137,3 +137,12 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: 10443
+              scheme: HTTPS
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/charts/clabernetes/tests/customized_values/test-fixtures/golden/deployment.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/golden/deployment.yaml
@@ -133,6 +133,15 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: 10443
+              scheme: HTTPS
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
       tolerations:
         - effect: PreferNoSchedule
           key: test_toleration

--- a/charts/clabernetes/tests/default_values/test-fixtures/golden/deployment.yaml
+++ b/charts/clabernetes/tests/default_values/test-fixtures/golden/deployment.yaml
@@ -127,3 +127,12 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: 10443
+              scheme: HTTPS
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/constants/env.go
+++ b/constants/env.go
@@ -112,6 +112,11 @@ const (
 	// containerlab to download and use in the launcher.
 	LauncherContainerlabVersion = "LAUNCHER_CONTAINERLAB_VERSION"
 
+	// LauncherStatusProbesEnabled tells the launcher to report the nested container's generic
+	// Docker readiness. Application-specific TCP and SSH probes, when configured, are additional
+	// requirements.
+	LauncherStatusProbesEnabled = "LAUNCHER_STATUS_PROBES_ENABLED"
+
 	// LauncherTCPProbePort is the env var that holds the port to use in the tcp probe (if
 	// configured).
 	LauncherTCPProbePort = "LAUNCHER_TCP_PROBE_PORT"

--- a/controllers/node/deployment.go
+++ b/controllers/node/deployment.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	probeInitialDelay                   = 60
-	probePeriodSeconds                  = 20
+	probeInitialDelay                   = 10
+	probePeriodSeconds                  = 10
 	probeReadinessFailureThreshold      = 3
-	probeDefaultStartupFailureThreshold = 40
+	probeDefaultStartupFailureThreshold = 90
 )
 
 // DeploymentReconciler renders/validates the launcher deployment for a Node -- exposed for
@@ -863,27 +863,34 @@ func (r *DeploymentReconciler) renderDeploymentContainerStatus(
 
 	if nodeProbeConfiguration.SSHProbeConfiguration == nil &&
 		nodeProbeConfiguration.TCPProbeConfiguration == nil {
-		r.log.Warnf("node %q has no status probe configurations, skipping...", nodeName)
-
-		return
+		r.log.Debugf(
+			"node %q has no application-specific status probe; using nested container state",
+			nodeName,
+		)
 	}
 
-	// default failure threshold for startup probe == 40, 40*20 = 800 seconds startup probe total
-	// time (plus the 60s initial delay) for 15ish min startup time...
+	// Keep roughly 15 minutes available for slow NOS image loading and startup. A successful
+	// startup probe hands control to the readiness probe immediately, so this generous failure
+	// budget does not delay fast nodes.
 	failureThresholds := probeDefaultStartupFailureThreshold
 
 	if nodeProbeConfiguration.StartupSeconds != 0 {
-		failureThresholds = nodeProbeConfiguration.StartupSeconds / probePeriodSeconds
+		// Round up so the rendered probe never allows less startup time than requested. Kubernetes
+		// requires a failure threshold of at least one.
+		failureThresholds = max(
+			1,
+			(nodeProbeConfiguration.StartupSeconds+probePeriodSeconds-1)/probePeriodSeconds,
+		)
 	}
 
-	// startup probe delays the start of the readiness probe -- this gives us time for the nos to
-	// boot before we start doing the readiness check on the (slightly) faster frequency
+	// The startup probe delays the readiness probe, giving a slow NOS time to boot without being
+	// presented as ready or restarted before its startup allowance expires.
 	deployment.Spec.Template.Spec.Containers[0].StartupProbe = &k8scorev1.Probe{
 		ProbeHandler: k8scorev1.ProbeHandler{
 			Exec: &k8scorev1.ExecAction{
 				Command: []string{
-					"grep",
-					clabernetesconstants.NodeStatusHealthy,
+					"test",
+					"-s",
 					clabernetesconstants.NodeStatusFile,
 				},
 			},
@@ -895,14 +902,13 @@ func (r *DeploymentReconciler) renderDeploymentContainerStatus(
 		FailureThreshold:    int32(failureThresholds),
 	}
 
-	// after the startup probe has done its thing we run the readiness probe -- since the
-	// launcher doesnt check the status super frequently we keep this pretty slow too
+	// After startup succeeds, the readiness probe tracks subsequent launcher status changes.
 	deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = &k8scorev1.Probe{
 		ProbeHandler: k8scorev1.ProbeHandler{
 			Exec: &k8scorev1.ExecAction{
 				Command: []string{
-					"grep",
-					clabernetesconstants.NodeStatusHealthy,
+					"test",
+					"-s",
 					clabernetesconstants.NodeStatusFile,
 				},
 			},
@@ -913,7 +919,12 @@ func (r *DeploymentReconciler) renderDeploymentContainerStatus(
 		FailureThreshold: probeReadinessFailureThreshold,
 	}
 
-	probeEnvVars := make([]k8scorev1.EnvVar, 0)
+	probeEnvVars := []k8scorev1.EnvVar{
+		{
+			Name:  clabernetesconstants.LauncherStatusProbesEnabled,
+			Value: clabernetesconstants.True,
+		},
+	}
 
 	if nodeProbeConfiguration.TCPProbeConfiguration != nil {
 		probeEnvVars = append(

--- a/controllers/node/deployment_test.go
+++ b/controllers/node/deployment_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"slices"
 	"testing"
 
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
@@ -206,5 +207,103 @@ func TestRenderDeploymentStandaloneHasNoGroupEnv(t *testing.T) {
 
 	if findEnv(container.Env, clabernetesconstants.LauncherGroupMembersEnv) != nil {
 		t.Fatal("expected no group members env for a standalone node")
+	}
+}
+
+func TestRenderDeploymentGenericStatusProbes(t *testing.T) {
+	node := &clabernetesapisv1alpha1.Node{}
+	node.Name = "generic-node"
+	node.Namespace = "clabernetes"
+	node.Spec.Image = "example.invalid/arbitrary-kind:latest"
+
+	reconciler := clabernetescontrollersnode.NewDeploymentReconciler(
+		&claberneteslogging.FakeInstance{},
+		"clabernetes",
+		"clabernetes",
+		clabernetesconstants.KubernetesCRIContainerd,
+		clabernetesconfig.GetFakeManager,
+	)
+
+	deployment := reconciler.Render(
+		&clabernetescontrollersnode.RenderInput{
+			Node: node,
+			Profile: testResolvedProfile(
+				t,
+				func(profile *clabernetescontrollersnode.ResolvedProfile) {
+					profile.StatusProbes.Enabled = true
+				},
+			),
+			GroupMembers: []string{"generic-node"},
+		},
+	)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	if container.StartupProbe == nil || container.ReadinessProbe == nil {
+		t.Fatal("expected generic startup and readiness probes without TCP or SSH configuration")
+	}
+
+	wantProbeCommand := []string{"test", "-s", clabernetesconstants.NodeStatusFile}
+
+	if !slices.Equal(container.StartupProbe.Exec.Command, wantProbeCommand) ||
+		!slices.Equal(container.ReadinessProbe.Exec.Command, wantProbeCommand) {
+		t.Fatalf(
+			"expected quiet status-file probes %v, got startup=%v readiness=%v",
+			wantProbeCommand,
+			container.StartupProbe.Exec.Command,
+			container.ReadinessProbe.Exec.Command,
+		)
+	}
+
+	if container.StartupProbe.InitialDelaySeconds != 10 ||
+		container.StartupProbe.PeriodSeconds != 10 ||
+		container.StartupProbe.FailureThreshold != 90 {
+		t.Fatalf("unexpected balanced startup probe timing: %+v", container.StartupProbe)
+	}
+
+	if container.ReadinessProbe.PeriodSeconds != 10 ||
+		container.ReadinessProbe.FailureThreshold != 3 {
+		t.Fatalf("unexpected balanced readiness probe timing: %+v", container.ReadinessProbe)
+	}
+
+	enabled := findEnv(container.Env, clabernetesconstants.LauncherStatusProbesEnabled)
+	if enabled == nil || enabled.Value != clabernetesconstants.True {
+		t.Fatalf("expected generic status probe enablement env, got %+v", enabled)
+	}
+
+	if findEnv(container.Env, clabernetesconstants.LauncherTCPProbePort) != nil ||
+		findEnv(container.Env, clabernetesconstants.LauncherSSHProbeUsername) != nil {
+		t.Fatal("generic readiness must not infer an application-specific TCP or SSH probe")
+	}
+}
+
+func TestRenderDeploymentRoundsCustomStartupAllowanceUp(t *testing.T) {
+	node := &clabernetesapisv1alpha1.Node{}
+	node.Name = "generic-node"
+	node.Namespace = "clabernetes"
+	node.Spec.Image = "example.invalid/arbitrary-kind:latest"
+
+	reconciler := clabernetescontrollersnode.NewDeploymentReconciler(
+		&claberneteslogging.FakeInstance{},
+		"clabernetes",
+		"clabernetes",
+		clabernetesconstants.KubernetesCRIContainerd,
+		clabernetesconfig.GetFakeManager,
+	)
+	deployment := reconciler.Render(
+		&clabernetescontrollersnode.RenderInput{
+			Node: node,
+			Profile: testResolvedProfile(
+				t,
+				func(profile *clabernetescontrollersnode.ResolvedProfile) {
+					profile.StatusProbes.Enabled = true
+					profile.StatusProbes.ProbeConfiguration.StartupSeconds = 21
+				},
+			),
+			GroupMembers: []string{"generic-node"},
+		},
+	)
+
+	if got := deployment.Spec.Template.Spec.Containers[0].StartupProbe.FailureThreshold; got != 3 {
+		t.Fatalf("custom 21-second startup allowance threshold = %d, want 3", got)
 	}
 }

--- a/docs/concepts/launcher-profiles.md
+++ b/docs/concepts/launcher-profiles.md
@@ -48,6 +48,16 @@ Profiles are not selected by labels and are not merged into inheritance chains. 
 referenced profile take precedence over global `Config` defaults; fields it omits continue through
 global resolution.
 
+When `statusProbes.enabled` is true, c9s considers a Node ready only after its nested Docker
+container is running and is not paused, restarting, or dead. If the container image defines a
+Docker healthcheck, that healthcheck must also report healthy. Optional TCP or SSH probe
+configuration adds an application-level requirement; c9s does not infer ports, credentials, or
+behavior from a containerlab kind or image name.
+
+For an image without a Docker healthcheck, this generic signal is intentionally process-level: a
+running network OS may still be booting services or converging protocols. Define a healthcheck in
+the image, or configure an explicit TCP or SSH probe, when application-level readiness is required.
+
 If a Node names a profile that does not exist, c9s does not silently fall back to global defaults.
 The Node remains unrealized until that explicit reference resolves.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -31,7 +31,7 @@ value -- dropping that would quietly change your lab.
 | `publish`, `sandbox`, `kernel`, `wait-for`, top-level `SANs` | Nothing -- containerlab itself removed these, so they made the launcher fail to parse the topology. `SANs` moved to `certificate.sans` |
 | `cpu`, `cpu-set`, `memory` | `LauncherProfile.resources` -- the pod's requests/limits are what actually bound a node |
 | `image-pull-policy` | `LauncherProfile.imagePull` |
-| `healthcheck` | `LauncherProfile.statusProbes` -- docker healthcheck status is invisible to Kubernetes |
+| `healthcheck` | `LauncherProfile.statusProbes` -- c9s bridges nested Docker state and image-defined healthchecks into Kubernetes readiness |
 | `runtime` | Nothing -- the launcher runs exactly one runtime (docker) |
 | `auto-remove` | Nothing -- the pod owns node lifecycle, and a removed container leaves a ready pod with no node |
 | `labels` | `metadata.labels` on the Node -- in a Topology `definition:` this is automatic, see below |

--- a/examples/basic/srl-multitool.yaml
+++ b/examples/basic/srl-multitool.yaml
@@ -3,7 +3,6 @@ apiVersion: c9s.run/v1alpha1
 kind: Topology
 metadata:
   name: srl-multitool
-  namespace: c9s
 spec:
   statusProbes:
     enabled: true

--- a/examples/basic/srl-multitool.yaml
+++ b/examples/basic/srl-multitool.yaml
@@ -3,17 +3,23 @@ apiVersion: c9s.run/v1alpha1
 kind: Topology
 metadata:
   name: srl-multitool
+  namespace: c9s
 spec:
   statusProbes:
     enabled: true
-    excludedNodes:
-      - multitool
-    probeConfiguration:
-      startupSeconds: 1200
-      sshProbeConfiguration:
-        username: admin
-        password: NokiaSrl1!
-        port: 22
+    nodeProbeConfigurations:
+      srl1:
+        startupSeconds: 1200
+        sshProbeConfiguration:
+          username: admin
+          password: NokiaSrl1!
+          port: 22
+      multitool:
+        startupSeconds: 1200
+        sshProbeConfiguration:
+          username: admin
+          password: multit00l
+          port: 22
   definition:
     containerlab: |
       name: srl-multitool

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -1454,7 +1454,7 @@
                                 "properties": {
                                     "enabled": {
                                         "default": true,
-                                        "description": "Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes\nare enabled and the health condition fails due to configuring the node the cluster will\nrestart the node. So, if you plan on being destructive with the node config (probably because\nyou will have exec'd onto the node) then you may want to disable this!",
+                                        "description": "Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously\nstarted but later fails its readiness check remains running and is reported not ready. A Node\nthat never passes its startup check is restarted after its startup allowance expires.",
                                         "type": "boolean"
                                     },
                                     "excludedNodes": {
@@ -1467,7 +1467,7 @@
                                     },
                                     "nodeProbeConfigurations": {
                                         "additionalProperties": {
-                                            "description": "ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If\nboth style probes are configured, both will be used and both must succeed in order to report\nhealthy.",
+                                            "description": "ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a\nTopology. If both styles are configured, both and the generic nested-container probe must succeed\nin order to report healthy.",
                                             "properties": {
                                                 "sshProbeConfiguration": {
                                                     "description": "SSHProbeConfiguration defines an SSH probe.",
@@ -1492,7 +1492,7 @@
                                                     "type": "object"
                                                 },
                                                 "startupSeconds": {
-                                                    "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60\ninitial delay configured, so technically the default is ~14-15 minutes. Be careful with this\ndelay as there must be time for c9s to (via whatever means) pull the image and load it into\ndocker on the launcher and this can take a bit! Having this be bigger than you think you need\nis generally better since if the startup probe succeeds ever then the readiness probe takes\nover anyway.",
+                                                    "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for\nc9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value\ndoes not delay fast nodes because the readiness probe takes over as soon as startup succeeds.",
                                                     "type": "integer"
                                                 },
                                                 "tcpProbeConfiguration": {
@@ -1540,7 +1540,7 @@
                                                 "type": "object"
                                             },
                                             "startupSeconds": {
-                                                "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60\ninitial delay configured, so technically the default is ~14-15 minutes. Be careful with this\ndelay as there must be time for c9s to (via whatever means) pull the image and load it into\ndocker on the launcher and this can take a bit! Having this be bigger than you think you need\nis generally better since if the startup probe succeeds ever then the readiness probe takes\nover anyway.",
+                                                "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for\nc9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value\ndoes not delay fast nodes because the readiness probe takes over as soon as startup succeeds.",
                                                 "type": "integer"
                                             },
                                             "tcpProbeConfiguration": {
@@ -2959,7 +2959,7 @@
                                 "properties": {
                                     "enabled": {
                                         "default": true,
-                                        "description": "Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes\nare enabled and the health condition fails due to configuring the node the cluster will\nrestart the node. So, if you plan on being destructive with the node config (probably because\nyou will have exec'd onto the node) then you may want to disable this!",
+                                        "description": "Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously\nstarted but later fails its readiness check remains running and is reported not ready. A Node\nthat never passes its startup check is restarted after its startup allowance expires.",
                                         "type": "boolean"
                                     },
                                     "excludedNodes": {
@@ -2972,7 +2972,7 @@
                                     },
                                     "nodeProbeConfigurations": {
                                         "additionalProperties": {
-                                            "description": "ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If\nboth style probes are configured, both will be used and both must succeed in order to report\nhealthy.",
+                                            "description": "ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a\nTopology. If both styles are configured, both and the generic nested-container probe must succeed\nin order to report healthy.",
                                             "properties": {
                                                 "sshProbeConfiguration": {
                                                     "description": "SSHProbeConfiguration defines an SSH probe.",
@@ -2997,7 +2997,7 @@
                                                     "type": "object"
                                                 },
                                                 "startupSeconds": {
-                                                    "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60\ninitial delay configured, so technically the default is ~14-15 minutes. Be careful with this\ndelay as there must be time for c9s to (via whatever means) pull the image and load it into\ndocker on the launcher and this can take a bit! Having this be bigger than you think you need\nis generally better since if the startup probe succeeds ever then the readiness probe takes\nover anyway.",
+                                                    "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for\nc9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value\ndoes not delay fast nodes because the readiness probe takes over as soon as startup succeeds.",
                                                     "type": "integer"
                                                 },
                                                 "tcpProbeConfiguration": {
@@ -3045,7 +3045,7 @@
                                                 "type": "object"
                                             },
                                             "startupSeconds": {
-                                                "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60\ninitial delay configured, so technically the default is ~14-15 minutes. Be careful with this\ndelay as there must be time for c9s to (via whatever means) pull the image and load it into\ndocker on the launcher and this can take a bit! Having this be bigger than you think you need\nis generally better since if the startup probe succeeds ever then the readiness probe takes\nover anyway.",
+                                                "description": "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults\nto roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for\nc9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value\ndoes not delay fast nodes because the readiness probe takes over as soon as startup succeeds.",
                                                 "type": "integer"
                                             },
                                             "tcpProbeConfiguration": {

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -3444,12 +3444,12 @@ func schema_clabernetes_clabernetes_apis_v1alpha1_ProbeConfiguration(
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ProbeConfiguration holds information about how to probe a (containerlab) node in a Topology. If both style probes are configured, both will be used and both must succeed in order to report healthy.",
+				Description: "ProbeConfiguration holds optional application-specific probes for a (containerlab) node in a Topology. If both styles are configured, both and the generic nested-container probe must succeed in order to report healthy.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"startupSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults to ~13 minutes to hopefully account for slow to boot nodes. Note that there is also a 60 initial delay configured, so technically the default is ~14-15 minutes. Be careful with this delay as there must be time for c9s to (via whatever means) pull the image and load it into docker on the launcher and this can take a bit! Having this be bigger than you think you need is generally better since if the startup probe succeeds ever then the readiness probe takes over anyway.",
+							Description: "StartupSeconds is the total amount of seconds to allow for the node to start. This defaults to roughly 15 minutes to account for slow-to-boot nodes. The allowance must include time for c9s to pull the image, load it into Docker on the launcher, and boot the node. A larger value does not delay fast nodes because the readiness probe takes over as soon as startup succeeds.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -3575,12 +3575,12 @@ func schema_clabernetes_clabernetes_apis_v1alpha1_StatusProbes(
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "StatusProbes holds details about if the status probes are enabled and if so how they should be handled.",
+				Description: "StatusProbes holds details about if the status probes are enabled and if so how they should be handled. Enabled probes always require the nested container to be running and not paused, restarting, or dead. If Docker exposes an image-defined healthcheck, it must also be healthy. Configured TCP and SSH probes are additional requirements.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled sets the status probes to enabled (or obviously disabled). Note that if the probes are enabled and the health condition fails due to configuring the node the cluster will restart the node. So, if you plan on being destructive with the node config (probably because you will have exec'd onto the node) then you may want to disable this!",
+							Description: "Enabled sets the status probes to enabled (or obviously disabled). A Node that has previously started but later fails its readiness check remains running and is reported not ready. A Node that never passes its startup check is restarted after its startup allowance expires.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/launcher/clabernetes.go
+++ b/launcher/clabernetes.go
@@ -21,7 +21,7 @@ import (
 const (
 	maxDockerLaunchAttempts  = 10
 	containerCheckInterval   = 5 * time.Second
-	statusProbeCheckInterval = 30 * time.Second
+	statusProbeCheckInterval = 10 * time.Second
 	statusProbeCheckTimeout  = 5 * time.Second
 	clientDefaultTimeout     = time.Minute
 	defaultSSHPort           = 22
@@ -115,6 +115,14 @@ func (c *clabernetes) startup() {
 	c.logger.Info("starting clabernetes...")
 
 	c.logger.Debugf("clabernetes version %s", clabernetesconstants.Version)
+
+	// The Kubernetes startup probe may begin while the launcher is still loading the node image.
+	// Create an explicitly unhealthy marker immediately so a normal startup wait is not reported
+	// as a missing-file error.
+	err := writeNodeStatus(clabernetesconstants.NodeStatusFile, false)
+	if err != nil {
+		c.logger.Fatalf("failed initializing node status file, error: %s", err)
+	}
 
 	c.fetchNodeResources()
 	c.containerlabVersion()
@@ -251,38 +259,8 @@ func (c *clabernetes) launch() {
 func (c *clabernetes) runProbes() {
 	c.logger.Debug("starting status probe(s) if configured...")
 
-	tcpProbePort := clabernetesutil.GetEnvIntOrDefault(clabernetesconstants.LauncherTCPProbePort, 0)
-
-	sshProbePort := clabernetesutil.GetEnvIntOrDefault(
-		clabernetesconstants.LauncherSSHProbePort,
-		defaultSSHPort,
-	)
-
-	sshProbeUsername := os.Getenv(clabernetesconstants.LauncherSSHProbeUsername)
-
-	sshProbePassword := os.Getenv(clabernetesconstants.LauncherSSHProbePassword)
-
-	var runTCPProbe bool
-
-	var runSSHProbe bool
-
-	if tcpProbePort != 0 {
-		c.logger.Debugf("will run tcp status probe to port %d", tcpProbePort)
-
-		runTCPProbe = true
-	}
-
-	if sshProbeUsername != "" && sshProbePassword != "" {
-		c.logger.Debugf(
-			"will run ssh status probe using username %s to port %d",
-			sshProbeUsername,
-			sshProbePort,
-		)
-
-		runSSHProbe = true
-	}
-
-	if !runTCPProbe && !runSSHProbe {
+	config, enabled := c.statusProbeConfiguration()
+	if !enabled {
 		c.logger.Debug("no probes configured, skipping status probes...")
 
 		return
@@ -291,64 +269,13 @@ func (c *clabernetes) runProbes() {
 	c.logger.Info("starting status probes...")
 
 	ticker := time.NewTicker(statusProbeCheckInterval)
+	defer ticker.Stop()
 
-	var nodeAddr string
-
-	for range ticker.C {
-		if nodeAddr == "" {
-			var err error
-
-			nodeAddr, err = getContainerAddr(c.ctx, c.nodeContainerID)
-			if err != nil {
-				c.logger.Warnf(
-					"failed determining node %q address, error: %s",
-					c.nodeName,
-					err,
-				)
-
-				continue
-			}
-		}
-
-		tcpProbeOk := true
-		sshProbeOk := true
-
-		if runTCPProbe {
-			dialer := net.Dialer{
-				Timeout: statusProbeCheckTimeout,
-			}
-
-			tcpConn, err := dialer.Dial(
-				"tcp",
-				net.JoinHostPort(nodeAddr, strconv.Itoa(tcpProbePort)),
-			)
-			if err != nil {
-				tcpProbeOk = false
-			} else {
-				_ = tcpConn.Close()
-			}
-		}
-
-		if runSSHProbe {
-			sshProbeOk = probeSSH(sshProbePort, nodeAddr, sshProbeUsername, sshProbePassword)
-		}
-
-		var writeErr error
-
-		if tcpProbeOk && sshProbeOk {
-			writeErr = os.WriteFile(
-				clabernetesconstants.NodeStatusFile,
-				[]byte(clabernetesconstants.NodeStatusHealthy),
-				clabernetesconstants.PermissionsEveryoneAllPermissions,
-			)
-		} else {
-			writeErr = os.WriteFile(
-				clabernetesconstants.NodeStatusFile,
-				nil,
-				clabernetesconstants.PermissionsEveryoneAllPermissions,
-			)
-		}
-
+	for {
+		writeErr := writeNodeStatus(
+			clabernetesconstants.NodeStatusFile,
+			c.getNodeReadiness(config),
+		)
 		if writeErr != nil {
 			c.logger.Criticalf(
 				"failed writing node status file, this probably should not happen, error: %s",
@@ -359,7 +286,134 @@ func (c *clabernetes) runProbes() {
 
 			return
 		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+		}
 	}
+}
+
+type statusProbeConfiguration struct {
+	tcpPort     int
+	sshPort     int
+	sshUsername string
+	sshPassword string
+}
+
+func (c *clabernetes) statusProbeConfiguration() (*statusProbeConfiguration, bool) {
+	config := &statusProbeConfiguration{
+		tcpPort: clabernetesutil.GetEnvIntOrDefault(
+			clabernetesconstants.LauncherTCPProbePort,
+			0,
+		),
+		sshPort: clabernetesutil.GetEnvIntOrDefault(
+			clabernetesconstants.LauncherSSHProbePort,
+			defaultSSHPort,
+		),
+		sshUsername: os.Getenv(clabernetesconstants.LauncherSSHProbeUsername),
+		sshPassword: os.Getenv(clabernetesconstants.LauncherSSHProbePassword),
+	}
+
+	if config.tcpPort != 0 {
+		c.logger.Debugf("will run tcp status probe to port %d", config.tcpPort)
+	}
+
+	sshEnabled := config.sshUsername != "" && config.sshPassword != ""
+	if sshEnabled {
+		c.logger.Debugf(
+			"will run ssh status probe using username %s to port %d",
+			config.sshUsername,
+			config.sshPort,
+		)
+	}
+
+	genericEnabled := clabernetesutil.GetEnvBoolOrDefault(
+		clabernetesconstants.LauncherStatusProbesEnabled,
+		false,
+	)
+
+	// An older manager does not set LauncherStatusProbesEnabled, so retain compatibility when it
+	// configures one of the original application-specific probes.
+	return config, genericEnabled || config.tcpPort != 0 || sshEnabled
+}
+
+func (c *clabernetes) getNodeReadiness(config *statusProbeConfiguration) bool {
+	containerReady, err := getContainerReadiness(c.ctx, c.nodeContainerID)
+	if err != nil {
+		c.logger.Warnf(
+			"failed determining node %q container readiness, error: %s",
+			c.nodeName,
+			err,
+		)
+
+		return false
+	}
+
+	if !containerReady {
+		return false
+	}
+
+	runTCPProbe := config.tcpPort != 0
+
+	runSSHProbe := config.sshUsername != "" && config.sshPassword != ""
+	if !runTCPProbe && !runSSHProbe {
+		return true
+	}
+
+	nodeAddr, err := getContainerAddr(c.ctx, c.nodeContainerID)
+	if err != nil {
+		c.logger.Warnf(
+			"failed determining node %q address, error: %s",
+			c.nodeName,
+			err,
+		)
+
+		return false
+	}
+
+	if runTCPProbe && !probeTCP(config.tcpPort, nodeAddr) {
+		return false
+	}
+
+	return !runSSHProbe || probeSSH(
+		config.sshPort,
+		nodeAddr,
+		config.sshUsername,
+		config.sshPassword,
+	)
+}
+
+func probeTCP(port int, nodeAddr string) bool {
+	dialer := net.Dialer{
+		Timeout: statusProbeCheckTimeout,
+	}
+
+	tcpConn, err := dialer.Dial(
+		"tcp",
+		net.JoinHostPort(nodeAddr, strconv.Itoa(port)),
+	)
+	if err != nil {
+		return false
+	}
+
+	_ = tcpConn.Close()
+
+	return true
+}
+
+func writeNodeStatus(path string, healthy bool) error {
+	var status []byte
+	if healthy {
+		status = []byte(clabernetesconstants.NodeStatusHealthy)
+	}
+
+	return os.WriteFile(
+		path,
+		status,
+		clabernetesconstants.PermissionsEveryoneAllPermissions,
+	)
 }
 
 func probeSSH(port int, nodeAddr, username, password string) bool {

--- a/launcher/docker.go
+++ b/launcher/docker.go
@@ -40,6 +40,18 @@ type daemonProxiesConfig struct {
 	NoProxy    string `json:"no-proxy,omitempty"`
 }
 
+type dockerContainerState struct {
+	Running    bool                   `json:"Running"`
+	Paused     bool                   `json:"Paused"`
+	Restarting bool                   `json:"Restarting"`
+	Dead       bool                   `json:"Dead"`
+	Health     *dockerContainerHealth `json:"Health,omitempty"`
+}
+
+type dockerContainerHealth struct {
+	Status string `json:"Status"`
+}
+
 func getProxiesConfig() *daemonProxiesConfig {
 	httpProxy := clabernetesutil.GetEnvStrOrDefault(
 		clabernetesconstants.HTTPProxyEnv,
@@ -292,4 +304,44 @@ func getContainerAddr(ctx context.Context, containerID string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(output)), nil
+}
+
+// getContainerReadiness reports the only readiness contract Docker exposes generically: the
+// container must be running and, when its image defines a Docker healthcheck, that healthcheck
+// must be healthy. It deliberately does not infer application ports or device-kind behavior.
+func getContainerReadiness(ctx context.Context, containerID string) (bool, error) {
+	inspectCmd := exec.CommandContext( //nolint:gosec
+		ctx,
+		"docker",
+		"inspect",
+		"--format",
+		"{{json .State}}",
+		containerID,
+	)
+
+	output, err := inspectCmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	return parseContainerReadiness(output)
+}
+
+func parseContainerReadiness(value []byte) (bool, error) {
+	state := &dockerContainerState{}
+
+	err := json.Unmarshal(value, state)
+	if err != nil {
+		return false, fmt.Errorf("failed decoding docker container state: %w", err)
+	}
+
+	if !state.Running || state.Paused || state.Restarting || state.Dead {
+		return false, nil
+	}
+
+	if state.Health == nil {
+		return true, nil
+	}
+
+	return strings.EqualFold(state.Health.Status, "healthy"), nil
 }

--- a/launcher/docker_test.go
+++ b/launcher/docker_test.go
@@ -2,6 +2,7 @@ package launcher //nolint:testpackage // tests cover unexported docker daemon co
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
@@ -88,6 +89,95 @@ func TestGetProxiesConfig(t *testing.T) { //nolint:paralleltest // mutates env v
 				t.Fatalf("expected proxies config %+v, got %+v", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestParseContainerReadiness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		state     string
+		wantReady bool
+		wantErr   bool
+	}{
+		{name: "running without healthcheck", state: `{"Running":true}`, wantReady: true},
+		{
+			name:      "running and healthy",
+			state:     `{"Running":true,"Health":{"Status":"healthy"}}`,
+			wantReady: true,
+		},
+		{
+			name:  "healthcheck starting",
+			state: `{"Running":true,"Health":{"Status":"starting"}}`,
+		},
+		{
+			name:  "healthcheck unhealthy",
+			state: `{"Running":true,"Health":{"Status":"unhealthy"}}`,
+		},
+		{name: "paused", state: `{"Running":true,"Paused":true}`},
+		{name: "restarting", state: `{"Running":true,"Restarting":true}`},
+		{name: "dead", state: `{"Running":true,"Dead":true}`},
+		{name: "not running", state: `{"Running":false}`},
+		{name: "invalid state", state: `{`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotReady, err := parseContainerReadiness([]byte(tt.state))
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseContainerReadiness() error = %v, wantErr %t", err, tt.wantErr)
+			}
+
+			if gotReady != tt.wantReady {
+				t.Fatalf(
+					"parseContainerReadiness() ready = %t, want %t",
+					gotReady,
+					tt.wantReady,
+				)
+			}
+		})
+	}
+}
+
+func TestWriteNodeStatus(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "status")
+
+	err := writeNodeStatus(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := os.ReadFile(path) //nolint:gosec // path is created inside t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(status) != 0 {
+		t.Fatalf("unhealthy status file = %q, want empty", status)
+	}
+
+	err = writeNodeStatus(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err = os.ReadFile(path) //nolint:gosec // path is created inside t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(status) != clabernetesconstants.NodeStatusHealthy {
+		t.Fatalf(
+			"healthy status file = %q, want %q",
+			status,
+			clabernetesconstants.NodeStatusHealthy,
+		)
 	}
 }
 

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/design.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/design.md
@@ -1,0 +1,114 @@
+## Context
+
+Before this change, the launcher only wrote a healthy status marker when an explicit TCP or SSH
+probe was configured. The Node Deployment rendered Kubernetes startup and readiness probes only
+for those same configurations, so a generic node had no readiness signal. Even configured probes
+did not account for the nested Docker container stopping, restarting, or reporting an image-defined
+healthcheck failure.
+
+The launcher already owns the nested Docker daemon and the status-file handoff to Kubernetes. The
+manager already exposes `/alive` and tracks whether controller-runtime startup has completed, but
+the manager Deployment used that endpoint only as a liveness probe.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every enabled, non-excluded Node a generic readiness baseline without inferring device kind,
+  image-specific ports, or credentials.
+- Preserve explicit TCP and SSH checks as additive application-level requirements.
+- Keep startup failure behavior bounded for slow network operating system images while making fast
+  nodes ready without waiting for the full allowance.
+- Make manager rollout availability depend on the existing controller-readiness state.
+- Preserve compatibility with launchers that receive only the legacy TCP/SSH environment variables.
+
+**Non-Goals:**
+
+- Defining application readiness for images without a Docker healthcheck or explicit TCP/SSH probe.
+- Adding a new readiness API field or changing Node status vocabulary.
+- Replacing the existing `/alive` endpoint or changing leader-election semantics.
+- Reporting structured readiness failure reasons through the status file.
+
+## Decisions
+
+### 1. Use Docker state and image healthchecks as the generic signal
+
+The launcher runs `docker inspect --format '{{json .State}}'` for the represented nested
+container. Readiness requires `Running=true` and rejects `Paused`, `Restarting`, and `Dead`.
+When Docker provides a health object, its status must be `healthy`; a missing health object means
+the image has no healthcheck and the running-state signal is accepted.
+
+This avoids hardcoded assumptions about node kinds, image names, management ports, or credentials.
+Inferring readiness from a port was rejected because generic images may expose no stable port or may
+expose a port before the service is usable.
+
+### 2. Compose generic and explicit probes additively
+
+`statusProbes.enabled` controls whether the launcher writes the status marker and whether the
+Deployment renders Kubernetes startup/readiness probes. The generic Docker signal is always
+evaluated when enabled. Configured TCP and SSH checks are evaluated after the generic signal and
+all configured checks must pass.
+
+The controller sets a dedicated `LAUNCHER_STATUS_PROBES_ENABLED` environment variable. The launcher
+also enables probing when legacy TCP or SSH variables are present, so a newer launcher remains
+compatible with an older manager during a rolling image transition.
+
+### 3. Represent unhealthy and healthy states with an empty/non-empty file
+
+The launcher creates `.nodestatus` as an empty file before image loading and container startup.
+Each probe cycle rewrites it with `healthy` only when all checks pass, otherwise it rewrites it
+empty. Kubernetes uses `test -s` for both startup and readiness probes.
+
+An empty marker is preferred over testing for file existence because it explicitly distinguishes the
+normal not-ready state from a healthy state without treating a missing file as a special startup
+error. It also avoids depending on `grep` being available or on the marker's textual contents.
+
+### 4. Poll immediately, then every 10 seconds
+
+The launcher evaluates readiness once as soon as probing starts and then uses a 10-second ticker.
+The Deployment uses a 10-second probe period, a 10-second initial delay, and a three-failure
+readiness threshold. The default startup failure threshold is 90 periods, retaining roughly
+15 minutes for image transfer and slow NOS startup. A configured `startupSeconds` value is rounded
+up to a whole 10-second period and bounded to at least one failure.
+
+This removes the old first-result delay of one full 30-second polling interval while retaining
+enough startup budget for large images. A successful startup probe immediately hands control to
+the readiness probe.
+
+### 5. Reuse `/alive` for manager readiness
+
+The chart adds a readiness probe to the manager container using the existing HTTPS `/alive`
+endpoint. The endpoint already returns success only after the controller-runtime cache is synced
+and controllers are registered (or when this replica is not the elected leader). No new endpoint
+or manager state machine is introduced.
+
+## Risks / Trade-offs
+
+- **Running without an image healthcheck is only process-level readiness** → Document this limitation
+  and require an image healthcheck or explicit TCP/SSH probe when service-level readiness matters.
+- **A Docker inspect error reports not ready** → Log the error and keep the status marker empty;
+  container lifecycle monitoring still handles a missing or terminated nested container.
+- **The empty marker does not expose a failure reason** → Keep diagnostics in launcher logs and avoid
+  coupling the probe contract to a new status schema.
+- **The default startup budget is intentionally generous** → Fast nodes are not delayed because the
+  first successful startup check transitions to readiness immediately.
+- **The manager readiness probe can delay rollout while controllers initialize** → This is intentional;
+  it prevents Kubernetes from advertising a manager that cannot yet reconcile resources.
+
+## Migration Plan
+
+No manifest migration is required. Existing `statusProbes` fields retain their names and explicit
+TCP/SSH configurations continue to work, but enabled profiles now also require the nested container
+and any image-defined healthcheck to be ready. Users whose images contain failing healthchecks must
+fix the healthcheck or disable status probes when process-level readiness is sufficient.
+
+The generated CRDs, OpenAPI documents, Helm templates, and golden fixtures are regenerated with the
+updated API descriptions. A rollback to the previous release remains possible; older launchers
+ignore the new enablement variable and retain the previous explicit-probe behavior.
+
+## Open Questions
+
+- Whether future versions should expose the Docker or application probe failure reason in Node
+  status rather than only in launcher logs.
+- Whether manager `/alive` should eventually be split into separate liveness and readiness
+  endpoints if controller startup and process health need independent semantics.

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/proposal.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`statusProbes.enabled` previously produced Kubernetes probes only when a TCP or SSH check was configured. Generic containerlab nodes therefore had no readiness signal, while configured probes ignored the nested Docker container's actual lifecycle and image healthcheck. Startup also reported a missing status file until the first slow polling interval, and the manager Deployment could be considered available before its controllers had finished starting.
+
+## What Changes
+
+- Define readiness for an enabled Node as an additive contract:
+  - the nested Docker container is running and is not paused, restarting, or dead;
+  - an image-defined Docker healthcheck, when present, is healthy;
+  - configured TCP and SSH probes remain additional application-level requirements.
+- Render startup and readiness probes for every non-excluded Node with `statusProbes.enabled`, including Nodes without TCP or SSH configuration.
+- Initialize the launcher status marker as explicitly unhealthy, update it immediately after launch, and poll readiness every 10 seconds while preserving roughly 15 minutes for slow startup.
+- Round custom startup allowances up to a whole probe interval so requested startup time is not shortened.
+- Add a manager Deployment readiness probe backed by `/alive`, so rollout availability waits for controller-runtime cache synchronization and controller registration.
+- Document the generic readiness contract and regenerate affected CRD/OpenAPI and Helm fixture artifacts.
+
+## Capabilities
+
+### New Capabilities
+
+- `manager-readiness`: Manager rollout availability uses the existing `/alive` controller-readiness signal.
+
+### Modified Capabilities
+
+- `node-lifecycle`: Node readiness is derived from the launcher-reported nested-container observation and is reflected for generic nodes, not only nodes with application probes.
+- `launcher-profiles`: Enabled `statusProbes` always establish the generic Docker readiness baseline; configured TCP and SSH checks are additive, and the startup/readiness timing contract is clarified.
+
+## Impact
+
+- Launcher readiness and Docker inspection in `launcher/clabernetes.go` and `launcher/docker.go`, including the launcher status marker and probe interval.
+- Node Deployment rendering and tests in `controllers/node/deployment.go` and `controllers/node/deployment_test.go`.
+- `StatusProbes` API descriptions, generated CRD/OpenAPI artifacts, Helm manager Deployment templates, and golden fixtures.
+- Launcher profile and upgrade documentation.
+- No new runtime dependency or user-facing API field is introduced.

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/launcher-profiles/spec.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/launcher-profiles/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Status probes compose generic and application readiness
+
+When a LauncherProfile enables status probes, the system SHALL establish the nested Docker
+container and image-healthcheck result as the baseline readiness signal. Configured TCP and SSH
+checks SHALL remain additional requirements and the system MUST NOT infer application checks from a
+Node kind, image name, port, or credentials.
+
+#### Scenario: Enabled profile supplies generic probes
+
+- **WHEN** a Node references a LauncherProfile with `statusProbes.enabled: true` and no TCP or SSH
+  configuration
+- **THEN** the rendered launcher Deployment contains startup and readiness probes and the launcher
+  receives an explicit status-probe enablement signal
+
+#### Scenario: Enabled profile supplies application probes
+
+- **WHEN** a LauncherProfile configures TCP or SSH checks
+- **THEN** the rendered launcher requires the generic nested-container signal and every configured
+  application check before reporting ready
+
+#### Scenario: Profile does not infer application behavior
+
+- **WHEN** an enabled LauncherProfile targets an arbitrary Node kind or image without explicit
+  application probe configuration
+- **THEN** the launcher performs no inferred TCP or SSH check
+
+#### Scenario: Custom startup allowance is preserved
+
+- **WHEN** a profile sets `statusProbes.probeConfiguration.startupSeconds` to a value that is not an
+  exact multiple of the probe period
+- **THEN** the rendered startup probe allows at least the requested duration by rounding up to a
+  whole probe interval
+
+#### Scenario: Fast startup is not delayed by the allowance
+
+- **WHEN** the nested container satisfies all readiness checks before the configured startup
+  allowance expires
+- **THEN** the startup probe succeeds and the readiness probe takes over without waiting for the
+  remaining allowance

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/manager-readiness/spec.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/manager-readiness/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Manager rollout readiness reflects controller startup
+
+The manager Deployment SHALL expose readiness through the existing `/alive` HTTPS endpoint, and
+the endpoint SHALL reflect the manager's existing readiness state: an elected leader becomes ready
+after controller-runtime startup completes, while a non-leader may become ready after another
+leader is observed.
+
+#### Scenario: Manager is still starting
+
+- **WHEN** the manager process is running but its controller-runtime cache has not synchronized or
+  its controllers have not finished registering
+- **THEN** `/alive` returns a non-success response and the manager Deployment is not ready
+
+#### Scenario: Manager startup is complete
+
+- **WHEN** the manager has synchronized its controller-runtime cache and completed controller
+  registration
+- **THEN** `/alive` returns success and Kubernetes may mark the manager Deployment ready
+
+#### Scenario: Manager is not the elected leader
+
+- **WHEN** the manager observes another replica as the elected leader
+- **THEN** `/alive` returns success for that replica so the Deployment can keep it available
+
+#### Scenario: Manager process fails its health endpoint
+
+- **WHEN** the manager's `/alive` readiness probe fails
+- **THEN** Kubernetes removes the manager Pod from ready endpoints and the Deployment rollout does
+  not count that Pod as available

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/node-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/specs/node-lifecycle/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Enabled Node readiness reflects generic launcher state
+
+When status probes are enabled for a non-excluded Node, the launcher SHALL report readiness only
+when the represented nested Docker container is running and is not paused, restarting, or dead. If
+the nested image defines a Docker healthcheck, that healthcheck SHALL also report `healthy`.
+
+#### Scenario: Generic Node has no application-specific probe
+
+- **WHEN** a Node uses an enabled status-probe configuration without TCP or SSH settings
+- **THEN** its launcher Deployment renders startup and readiness probes and reports the generic
+  nested-container readiness through the launcher status marker
+
+#### Scenario: Running container without a healthcheck
+
+- **WHEN** the represented nested container is running, not paused, not restarting, not dead, and
+  has no Docker healthcheck
+- **THEN** the Node reports ready under the generic readiness contract
+
+#### Scenario: Nested container is not runnable
+
+- **WHEN** the represented nested container is stopped, paused, restarting, or dead
+- **THEN** the Node reports not ready
+
+#### Scenario: Image healthcheck is not healthy
+
+- **WHEN** the represented nested container is running but its Docker healthcheck is `starting` or
+  `unhealthy`
+- **THEN** the Node reports not ready
+
+#### Scenario: Image healthcheck becomes healthy
+
+- **WHEN** a running nested container's Docker healthcheck reports `healthy`
+- **THEN** the generic readiness condition succeeds
+
+#### Scenario: Explicit application probe fails
+
+- **WHEN** the nested container satisfies the generic readiness contract but a configured TCP or
+  SSH probe fails
+- **THEN** the Node remains not ready
+
+#### Scenario: Status probes are disabled or excluded
+
+- **WHEN** status probes are disabled for a Node or the Node is listed in `excludedNodes`
+- **THEN** the controller does not render launcher status probes for that Node

--- a/openspec/changes/archive/2026-08-12-generic-node-readiness/tasks.md
+++ b/openspec/changes/archive/2026-08-12-generic-node-readiness/tasks.md
@@ -1,0 +1,25 @@
+## 1. Launcher readiness signal
+
+- [x] 1.1 Add Docker container-state and image-healthcheck decoding for generic readiness, including unit coverage for running, paused, restarting, dead, unhealthy, healthy, missing-healthcheck, and malformed states.
+- [x] 1.2 Initialize the launcher status marker as empty before image loading and centralize empty/healthy marker writes.
+- [x] 1.3 Compose the generic Docker signal with optional TCP and SSH checks, and preserve legacy explicit-probe environment compatibility.
+- [x] 1.4 Evaluate readiness immediately after launch and poll every 10 seconds, retaining the configured startup allowance and handling Docker inspection failures as not ready.
+
+## 2. Kubernetes probe rendering
+
+- [x] 2.1 Render startup and readiness probes whenever enabled status probes apply, even when no TCP or SSH probe is configured.
+- [x] 2.2 Use non-empty status-file checks, pass the generic enablement environment variable, and round custom startup allowances up to a whole probe period.
+- [x] 2.3 Add controller deployment tests for generic probes, additive application probes, balanced timing, and custom startup rounding.
+- [x] 2.4 Add the manager Deployment readiness probe backed by `/alive` and refresh Helm deployment golden fixtures.
+
+## 3. API and documentation surfaces
+
+- [x] 3.1 Update `StatusProbes` and `ProbeConfiguration` API descriptions to define the generic and additive readiness contract.
+- [x] 3.2 Regenerate CRD and OpenAPI artifacts and verify generated output is reproducible.
+- [x] 3.3 Document process-level readiness, image healthcheck behavior, and explicit application-probe requirements in launcher-profile and upgrade documentation.
+
+## 4. Verification
+
+- [x] 4.1 Run linting, race-enabled tests, package builds, documentation checks, documentation builds, and manager/launcher image builds.
+- [x] 4.2 Run lifecycle validation for deploy, inspect, exec, dataplane connectivity, stop/start/restart, events, and destroy.
+- [x] 4.3 Verify readiness improvement on a generic multitool workload, reducing observed readiness from approximately 84 seconds to approximately 34–35 seconds.

--- a/openspec/specs/launcher-profiles/spec.md
+++ b/openspec/specs/launcher-profiles/spec.md
@@ -15,6 +15,46 @@ The system SHALL provide a namespaced LauncherProfile resource for reusable Kube
 - **WHEN** multiple Nodes explicitly reference one LauncherProfile
 - **THEN** each Node is realized using the same declared launcher policy
 
+### Requirement: Status probes compose generic and application readiness
+
+When a LauncherProfile enables status probes, the system SHALL establish the nested Docker
+container and image-healthcheck result as the baseline readiness signal. Configured TCP and SSH
+checks SHALL remain additional requirements and the system MUST NOT infer application checks from a
+Node kind, image name, port, or credentials.
+
+#### Scenario: Enabled profile supplies generic probes
+
+- **WHEN** a Node references a LauncherProfile with `statusProbes.enabled: true` and no TCP or SSH
+  configuration
+- **THEN** the rendered launcher Deployment contains startup and readiness probes and the launcher
+  receives an explicit status-probe enablement signal
+
+#### Scenario: Enabled profile supplies application probes
+
+- **WHEN** a LauncherProfile configures TCP or SSH checks
+- **THEN** the rendered launcher requires the generic nested-container signal and every configured
+  application check before reporting ready
+
+#### Scenario: Profile does not infer application behavior
+
+- **WHEN** an enabled LauncherProfile targets an arbitrary Node kind or image without explicit
+  application probe configuration
+- **THEN** the launcher performs no inferred TCP or SSH check
+
+#### Scenario: Custom startup allowance is preserved
+
+- **WHEN** a profile sets `statusProbes.probeConfiguration.startupSeconds` to a value that is not an
+  exact multiple of the probe period
+- **THEN** the rendered startup probe allows at least the requested duration by rounding up to a
+  whole probe interval
+
+#### Scenario: Fast startup is not delayed by the allowance
+
+- **WHEN** the nested container satisfies all readiness checks before the configured startup
+  allowance expires
+- **THEN** the startup probe succeeds and the readiness probe takes over without waiting for the
+  remaining allowance
+
 ### Requirement: LauncherProfile excludes network topology intent except management compatibility
 
 LauncherProfile MUST NOT define Node endpoints, Link connectivity flavor, per-device management addresses, or per-node payload attachments. It MAY retain shared Containerlab management-network configuration as a temporary compatibility field so existing Topology manifests preserve their behavior until that configuration receives a dedicated owner.

--- a/openspec/specs/manager-readiness/spec.md
+++ b/openspec/specs/manager-readiness/spec.md
@@ -1,0 +1,37 @@
+# manager-readiness Specification
+
+## Purpose
+
+Define manager rollout readiness through the manager's existing health endpoint and controller startup state.
+
+## Requirements
+
+### Requirement: Manager rollout readiness reflects controller startup
+
+The manager Deployment SHALL expose readiness through the existing `/alive` HTTPS endpoint, and
+the endpoint SHALL reflect the manager's existing readiness state: an elected leader becomes ready
+after controller-runtime startup completes, while a non-leader may become ready after another
+leader is observed.
+
+#### Scenario: Manager is still starting
+
+- **WHEN** the manager process is running but its controller-runtime cache has not synchronized or
+  its controllers have not finished registering
+- **THEN** `/alive` returns a non-success response and the manager Deployment is not ready
+
+#### Scenario: Manager startup is complete
+
+- **WHEN** the manager has synchronized its controller-runtime cache and completed controller
+  registration
+- **THEN** `/alive` returns success and Kubernetes may mark the manager Deployment ready
+
+#### Scenario: Manager is not the elected leader
+
+- **WHEN** the manager observes another replica as the elected leader
+- **THEN** `/alive` returns success for that replica so the Deployment can keep it available
+
+#### Scenario: Manager process fails its health endpoint
+
+- **WHEN** the manager's `/alive` readiness probe fails
+- **THEN** Kubernetes removes the manager Pod from ready endpoints and the Deployment rollout does
+  not count that Pod as available

--- a/openspec/specs/node-lifecycle/spec.md
+++ b/openspec/specs/node-lifecycle/spec.md
@@ -190,6 +190,51 @@ The controller SHALL record Node readiness, probe observations, exposed-port all
 - **WHEN** the launcher Pod or configured probes change readiness
 - **THEN** the controller updates only the affected Node readiness and conditions
 
+### Requirement: Enabled Node readiness reflects generic launcher state
+
+When status probes are enabled for a non-excluded Node, the launcher SHALL report readiness only
+when the represented nested Docker container is running and is not paused, restarting, or dead. If
+the nested image defines a Docker healthcheck, that healthcheck SHALL also report `healthy`.
+
+#### Scenario: Generic Node has no application-specific probe
+
+- **WHEN** a Node uses an enabled status-probe configuration without TCP or SSH settings
+- **THEN** its launcher Deployment renders startup and readiness probes and reports the generic
+  nested-container readiness through the launcher status marker
+
+#### Scenario: Running container without a healthcheck
+
+- **WHEN** the represented nested container is running, not paused, not restarting, not dead, and
+  has no Docker healthcheck
+- **THEN** the Node reports ready under the generic readiness contract
+
+#### Scenario: Nested container is not runnable
+
+- **WHEN** the represented nested container is stopped, paused, restarting, or dead
+- **THEN** the Node reports not ready
+
+#### Scenario: Image healthcheck is not healthy
+
+- **WHEN** the represented nested container is running but its Docker healthcheck is `starting` or
+  `unhealthy`
+- **THEN** the Node reports not ready
+
+#### Scenario: Image healthcheck becomes healthy
+
+- **WHEN** a running nested container's Docker healthcheck reports `healthy`
+- **THEN** the generic readiness condition succeeds
+
+#### Scenario: Explicit application probe fails
+
+- **WHEN** the nested container satisfies the generic readiness contract but a configured TCP or
+  SSH probe fails
+- **THEN** the Node remains not ready
+
+#### Scenario: Status probes are disabled or excluded
+
+- **WHEN** status probes are disabled for a Node or the Node is listed in `excludedNodes`
+- **THEN** the controller does not render launcher status probes for that Node
+
 ### Requirement: Individual Node object size is independent of topology size
 
 A Node resource SHALL contain only its own definition, payload references, launcher profile reference, and status. The system MUST NOT copy all topology Nodes, Links, or aggregate child statuses into a Node.


### PR DESCRIPTION
## Summary

- bridge nested Docker container state and image-defined healthchecks into Kubernetes startup and readiness probes
- render generic status probes whenever `statusProbes.enabled` is true, with configured TCP and SSH checks remaining additional requirements
- initialize the launcher status marker immediately and use balanced 10-second polling while retaining roughly 15 minutes for slow NOS startup
- document the generic readiness contract and regenerate CRD/OpenAPI artifacts

## Motivation

Status probes were previously rendered only when a TCP or SSH probe was configured. This left generic containerlab nodes without a readiness signal, while the launcher could also emit missing-status-file probe events and wait up to a full polling interval before reporting a fast node ready.

Readiness should work across containerlab kinds without hardcoded image, kind, port, or credential assumptions.

## Behavior

A node is ready when its nested Docker container is running and is not paused, restarting, or dead. If the image defines a Docker healthcheck, that healthcheck must also be healthy. Explicit TCP and SSH probes are additive.

For images without a healthcheck or explicit application probe, the generic signal is intentionally process-level.

## Validation

- `make lint`
- `make run-generate` twice with identical generated output
- `make test-race` (290 tests)
- `go build ./...`
- `make check-docs`
- `make build-docs`
- `make build-manager build-launcher`
- fresh c9s lifecycle validation covering deploy, inspect, exec, dataplane connectivity, stop/start/restart, events, and destroy
- fresh multitool readiness measured at approximately 34–35 seconds, down from approximately 84 seconds
