### PR TITLE
Harden topology compilation and grouped node readiness

### DIFF
--- a/.cursor/rules/docs-browser-testing.mdc
+++ b/.cursor/rules/docs-browser-testing.mdc
@@ -1,0 +1,12 @@
+---
+description: Run browser-based documentation tests only when explicitly requested
+alwaysApply: true
+---
+
+# Browser-based documentation testing
+
+- Do not automatically load or run `test-fumadocs-wrangler` after documentation edits.
+- Only use the browser-based Wrangler/Playwright skill when the user explicitly requests
+  browser-based, headless, Wrangler, production-like, direct-load, refresh, or redirect testing.
+- Static documentation checks such as build, typecheck, link validation, and unit tests may run when
+  relevant, but do not launch a browser or Wrangler without explicit user approval.

--- a/controllers/node/controller.go
+++ b/controllers/node/controller.go
@@ -51,6 +51,7 @@ func NewController(
 		reconciler: NewReconciler(
 			baseController.Log,
 			baseController.Client,
+			clabernetes.GetCtrlRuntimeMgr().GetAPIReader(),
 			clabernetes.GetAppName(),
 			clabernetes.GetNamespace(),
 			clabernetes.GetClusterCRIKind(),

--- a/controllers/node/reconcile.go
+++ b/controllers/node/reconcile.go
@@ -18,6 +18,7 @@ import (
 	apimachinerymeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	clientretry "k8s.io/client-go/util/retry"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -452,9 +453,39 @@ func (r *Reconciler) updateNodeStatus(
 		return nil
 	}
 
-	node.Status = desiredStatus
+	key := ctrlruntimeclient.ObjectKeyFromObject(node)
 
-	return r.Client.Update(ctx, node)
+	var updated *clabernetesapisv1alpha1.Node
+
+	err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+		current := &clabernetesapisv1alpha1.Node{}
+
+		err := r.Client.Get(ctx, key, current)
+		if err != nil {
+			return err
+		}
+
+		if reflect.DeepEqual(current.Status, desiredStatus) {
+			updated = current
+
+			return nil
+		}
+
+		current.Status = desiredStatus
+
+		updateErr := r.Client.Update(ctx, current)
+		if updateErr == nil {
+			updated = current
+		}
+
+		return updateErr
+	})
+	if err == nil && updated != nil {
+		node.Status = updated.Status
+		node.SetResourceVersion(updated.GetResourceVersion())
+	}
+
+	return err
 }
 
 func (r *Reconciler) reconcileDeployment(

--- a/controllers/node/reconcile.go
+++ b/controllers/node/reconcile.go
@@ -33,6 +33,7 @@ type Reconciler struct {
 	Client ctrlruntimeclient.Client
 
 	configManagerGetter clabernetesconfig.ManagerGetterFunc
+	apiReader           ctrlruntimeclient.Reader
 
 	namespaceResourcesReconciler *NamespaceResourcesReconciler
 
@@ -46,6 +47,7 @@ type Reconciler struct {
 func NewReconciler(
 	log claberneteslogging.Instance,
 	client ctrlruntimeclient.Client,
+	apiReader ctrlruntimeclient.Reader,
 	managerAppName,
 	managerNamespace,
 	criKind string,
@@ -55,6 +57,7 @@ func NewReconciler(
 		Log:                 log,
 		Client:              client,
 		configManagerGetter: configManagerGetter,
+		apiReader:           apiReader,
 		namespaceResourcesReconciler: NewNamespaceResourcesReconciler(
 			log,
 			client,
@@ -454,13 +457,18 @@ func (r *Reconciler) updateNodeStatus(
 	}
 
 	key := ctrlruntimeclient.ObjectKeyFromObject(node)
+	reader := r.apiReader
+
+	if reader == nil {
+		reader = r.Client
+	}
 
 	var updated *clabernetesapisv1alpha1.Node
 
 	err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		current := &clabernetesapisv1alpha1.Node{}
 
-		err := r.Client.Get(ctx, key, current)
+		err := reader.Get(ctx, key, current)
 		if err != nil {
 			return err
 		}

--- a/controllers/node/reconcile_test.go
+++ b/controllers/node/reconcile_test.go
@@ -29,7 +29,8 @@ import (
 type conflictOnceClient struct {
 	ctrlruntimeclient.Client
 
-	updateCalls int
+	updateCalls    int
+	beforeConflict func(context.Context, ctrlruntimeclient.Object) error
 }
 
 type countingNodeReader struct {
@@ -58,6 +59,13 @@ func (c *conflictOnceClient) Update(
 ) error {
 	c.updateCalls++
 	if c.updateCalls == 1 {
+		if c.beforeConflict != nil {
+			err := c.beforeConflict(ctx, obj)
+			if err != nil {
+				return err
+			}
+		}
+
 		return apimachineryerrors.NewConflict(
 			apimachineryschema.GroupResource{Group: "c9s.run", Resource: "nodes"},
 			obj.GetName(),
@@ -74,7 +82,21 @@ func TestUpdateNodeStatusRetriesResourceVersionConflict(t *testing.T) {
 	scheme := nodeReconcileTestScheme(t)
 	node := nodeReconcileTestNode()
 	baseClient := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
-	client := &conflictOnceClient{Client: baseClient}
+	client := &conflictOnceClient{
+		Client: baseClient,
+		beforeConflict: func(ctx context.Context, obj ctrlruntimeclient.Object) error {
+			current := &clabernetesapisv1alpha1.Node{}
+
+			err := baseClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), current)
+			if err != nil {
+				return err
+			}
+
+			current.Status.Readiness = clabernetesconstants.NodeStatusNotReady
+
+			return baseClient.Update(ctx, current)
+		},
+	}
 	apiReader := &countingNodeReader{Reader: baseClient}
 	reconciler := &Reconciler{Client: client, apiReader: apiReader}
 	desired := clabernetesapisv1alpha1.NodeStatus{

--- a/controllers/node/reconcile_test.go
+++ b/controllers/node/reconcile_test.go
@@ -32,6 +32,23 @@ type conflictOnceClient struct {
 	updateCalls int
 }
 
+type countingNodeReader struct {
+	ctrlruntimeclient.Reader
+
+	getCalls int
+}
+
+func (r *countingNodeReader) Get(
+	ctx context.Context,
+	key ctrlruntimeclient.ObjectKey,
+	obj ctrlruntimeclient.Object,
+	opts ...ctrlruntimeclient.GetOption,
+) error {
+	r.getCalls++
+
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
 var errInjectedNodeConflict = errors.New("injected conflict")
 
 func (c *conflictOnceClient) Update(
@@ -58,7 +75,8 @@ func TestUpdateNodeStatusRetriesResourceVersionConflict(t *testing.T) {
 	node := nodeReconcileTestNode()
 	baseClient := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
 	client := &conflictOnceClient{Client: baseClient}
-	reconciler := &Reconciler{Client: client}
+	apiReader := &countingNodeReader{Reader: baseClient}
+	reconciler := &Reconciler{Client: client, apiReader: apiReader}
 	desired := clabernetesapisv1alpha1.NodeStatus{
 		Readiness: clabernetesconstants.NodeStatusReady,
 	}
@@ -70,6 +88,10 @@ func TestUpdateNodeStatusRetriesResourceVersionConflict(t *testing.T) {
 
 	if client.updateCalls != 2 {
 		t.Fatalf("status update calls = %d, want 2", client.updateCalls)
+	}
+
+	if apiReader.getCalls != 2 {
+		t.Fatalf("direct status reads = %d, want 2", apiReader.getCalls)
 	}
 
 	actual := &clabernetesapisv1alpha1.Node{}
@@ -397,6 +419,7 @@ func TestReconcileFailsClosedForMissingLauncherProfile(t *testing.T) {
 	reconciler := NewReconciler(
 		&claberneteslogging.FakeInstance{},
 		client,
+		client,
 		"clabernetes",
 		"clabernetes",
 		clabernetesconstants.KubernetesCRIContainerd,
@@ -615,6 +638,7 @@ func TestReconcileGroupedNodesInheritPrimaryLauncherProfile(t *testing.T) {
 	reconciler := NewReconciler(
 		&claberneteslogging.FakeInstance{},
 		client,
+		client,
 		"clabernetes",
 		"clabernetes",
 		clabernetesconstants.KubernetesCRIContainerd,
@@ -669,6 +693,7 @@ func TestReconcileRejectsGroupedLauncherProfileConflict(t *testing.T) {
 		Build()
 	reconciler := NewReconciler(
 		&claberneteslogging.FakeInstance{},
+		client,
 		client,
 		"clabernetes",
 		"clabernetes",

--- a/controllers/node/reconcile_test.go
+++ b/controllers/node/reconcile_test.go
@@ -2,6 +2,7 @@ package node //nolint:testpackage // tests exercise unexported reconciliation he
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
@@ -17,12 +18,75 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrlruntimeutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+type conflictOnceClient struct {
+	ctrlruntimeclient.Client
+
+	updateCalls int
+}
+
+var errInjectedNodeConflict = errors.New("injected conflict")
+
+func (c *conflictOnceClient) Update(
+	ctx context.Context,
+	obj ctrlruntimeclient.Object,
+	opts ...ctrlruntimeclient.UpdateOption,
+) error {
+	c.updateCalls++
+	if c.updateCalls == 1 {
+		return apimachineryerrors.NewConflict(
+			apimachineryschema.GroupResource{Group: "c9s.run", Resource: "nodes"},
+			obj.GetName(),
+			errInjectedNodeConflict,
+		)
+	}
+
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func TestUpdateNodeStatusRetriesResourceVersionConflict(t *testing.T) {
+	t.Parallel()
+
+	scheme := nodeReconcileTestScheme(t)
+	node := nodeReconcileTestNode()
+	baseClient := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	client := &conflictOnceClient{Client: baseClient}
+	reconciler := &Reconciler{Client: client}
+	desired := clabernetesapisv1alpha1.NodeStatus{
+		Readiness: clabernetesconstants.NodeStatusReady,
+	}
+
+	err := reconciler.updateNodeStatus(context.Background(), node, desired)
+	if err != nil {
+		t.Fatalf("updateNodeStatus() failed after retryable conflict: %s", err)
+	}
+
+	if client.updateCalls != 2 {
+		t.Fatalf("status update calls = %d, want 2", client.updateCalls)
+	}
+
+	actual := &clabernetesapisv1alpha1.Node{}
+
+	err = baseClient.Get(
+		context.Background(),
+		ctrlruntimeclient.ObjectKeyFromObject(node),
+		actual,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual.Status.Readiness != clabernetesconstants.NodeStatusReady {
+		t.Fatalf("stored readiness = %q, want ready", actual.Status.Readiness)
+	}
+}
 
 func TestReconcileFabricServicePreservesClusterAllocation(t *testing.T) {
 	scheme := nodeReconcileTestScheme(t)

--- a/controllers/topology/compile.go
+++ b/controllers/topology/compile.go
@@ -50,19 +50,23 @@ func (e *UnsupportedFeaturesError) Error() string {
 
 	parts := make([]string, 0, len(e.Diagnostics))
 	for _, diagnostic := range e.Diagnostics {
-		location := diagnostic.Path
-		if location == "" {
-			location = "topology"
-		}
-
-		if diagnostic.Line > 0 {
-			location = fmt.Sprintf("%s (line %d)", location, diagnostic.Line)
-		}
-
-		parts = append(parts, fmt.Sprintf("%s: %s", location, diagnostic.Message))
+		parts = append(parts, formatCompilerDiagnostic(diagnostic))
 	}
 
 	return "topology contains features unsupported by c9s: " + strings.Join(parts, "; ")
+}
+
+func formatCompilerDiagnostic(diagnostic CompilerDiagnostic) string {
+	location := diagnostic.Path
+	if location == "" {
+		location = "topology"
+	}
+
+	if diagnostic.Line > 0 {
+		location = fmt.Sprintf("%s (line %d)", location, diagnostic.Line)
+	}
+
+	return fmt.Sprintf("%s: %s", location, diagnostic.Message)
 }
 
 type compileDiagnostics struct {
@@ -89,7 +93,7 @@ func (d *compileDiagnostics) add(diagnostic CompilerDiagnostic, alwaysError bool
 	d.forceError = d.forceError || alwaysError
 
 	if d.policy == UnsupportedFieldPolicyWarn && !alwaysError {
-		d.logger.Warn(diagnostic.Message)
+		d.logger.Warn(formatCompilerDiagnostic(diagnostic))
 	}
 }
 

--- a/controllers/topology/compile.go
+++ b/controllers/topology/compile.go
@@ -2,6 +2,8 @@ package topology
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	clabernetesapis "github.com/clabernetes/clabernetes/apis"
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
@@ -9,6 +11,113 @@ import (
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
 )
+
+// UnsupportedFieldPolicy controls how the compiler handles source vocabulary that c9s can
+// parse, but cannot preserve with the same semantics. The in-cluster compatibility controller
+// uses Warn; callers promising a strict containerlab-compatible runtime use Error.
+type UnsupportedFieldPolicy string
+
+const (
+	// UnsupportedFieldPolicyWarn preserves compatibility and logs lossy source fields.
+	UnsupportedFieldPolicyWarn UnsupportedFieldPolicy = "warn"
+	// UnsupportedFieldPolicyError rejects any source field c9s cannot preserve.
+	UnsupportedFieldPolicyError UnsupportedFieldPolicy = "error"
+)
+
+// CompileOptions controls compatibility behavior while compiling a source Topology.
+type CompileOptions struct {
+	UnsupportedFieldPolicy UnsupportedFieldPolicy
+}
+
+// CompilerDiagnostic describes one source construct that c9s cannot faithfully preserve.
+type CompilerDiagnostic struct {
+	Code    string
+	Path    string
+	Line    int
+	Message string
+}
+
+// UnsupportedFeaturesError reports all unsupported source constructs found in one compile pass.
+// Diagnostics are sorted so CLI errors and tests remain stable across map iteration order.
+type UnsupportedFeaturesError struct {
+	Diagnostics []CompilerDiagnostic
+}
+
+func (e *UnsupportedFeaturesError) Error() string {
+	if e == nil || len(e.Diagnostics) == 0 {
+		return "topology contains features unsupported by c9s"
+	}
+
+	parts := make([]string, 0, len(e.Diagnostics))
+	for _, diagnostic := range e.Diagnostics {
+		location := diagnostic.Path
+		if location == "" {
+			location = "topology"
+		}
+
+		if diagnostic.Line > 0 {
+			location = fmt.Sprintf("%s (line %d)", location, diagnostic.Line)
+		}
+
+		parts = append(parts, fmt.Sprintf("%s: %s", location, diagnostic.Message))
+	}
+
+	return "topology contains features unsupported by c9s: " + strings.Join(parts, "; ")
+}
+
+type compileDiagnostics struct {
+	logger      claberneteslogging.Instance
+	policy      UnsupportedFieldPolicy
+	diagnostics []CompilerDiagnostic
+	forceError  bool
+}
+
+func newCompileDiagnostics(
+	logger claberneteslogging.Instance,
+	options CompileOptions,
+) *compileDiagnostics {
+	policy := options.UnsupportedFieldPolicy
+	if policy == "" {
+		policy = UnsupportedFieldPolicyWarn
+	}
+
+	return &compileDiagnostics{logger: logger, policy: policy}
+}
+
+func (d *compileDiagnostics) add(diagnostic CompilerDiagnostic, alwaysError bool) {
+	d.diagnostics = append(d.diagnostics, diagnostic)
+	d.forceError = d.forceError || alwaysError
+
+	if d.policy == UnsupportedFieldPolicyWarn && !alwaysError {
+		d.logger.Warn(diagnostic.Message)
+	}
+}
+
+func (d *compileDiagnostics) err() error {
+	if len(d.diagnostics) == 0 ||
+		(d.policy != UnsupportedFieldPolicyError && !d.forceError) {
+		return nil
+	}
+
+	diagnostics := append([]CompilerDiagnostic(nil), d.diagnostics...)
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+
+		if diagnostics[i].Line != diagnostics[j].Line {
+			return diagnostics[i].Line < diagnostics[j].Line
+		}
+
+		if diagnostics[i].Code != diagnostics[j].Code {
+			return diagnostics[i].Code < diagnostics[j].Code
+		}
+
+		return diagnostics[i].Message < diagnostics[j].Message
+	})
+
+	return &UnsupportedFeaturesError{Diagnostics: diagnostics}
+}
 
 // CompiledLink holds a single wire of a compiled topology definition -- exactly the payload of
 // a Link spec.
@@ -42,6 +151,18 @@ func CompileTopology(
 	logger claberneteslogging.Instance,
 	topology *clabernetesapisv1alpha1.Topology,
 ) (*CompiledTopology, error) {
+	return CompileTopologyWithOptions(logger, topology, CompileOptions{
+		UnsupportedFieldPolicy: UnsupportedFieldPolicyWarn,
+	})
+}
+
+// CompileTopologyWithOptions parses and compiles a Topology using the requested compatibility
+// policy. Structurally impossible constructs remain errors under every policy.
+func CompileTopologyWithOptions(
+	logger claberneteslogging.Instance,
+	topology *clabernetesapisv1alpha1.Topology,
+	options CompileOptions,
+) (*CompiledTopology, error) {
 	if topology.Spec.Definition.Containerlab == "" {
 		return nil, fmt.Errorf(
 			"%w: topology definition must include a containerlab topology",
@@ -49,7 +170,11 @@ func CompileTopology(
 		)
 	}
 
-	return compileContainerlabDefinition(logger, topology.Spec.Definition.Containerlab)
+	return compileContainerlabDefinition(
+		logger,
+		topology.Spec.Definition.Containerlab,
+		newCompileDiagnostics(logger, options),
+	)
 }
 
 // GetTopologyKind returns the "kind" of topology this CR represents.

--- a/controllers/topology/compile_test.go
+++ b/controllers/topology/compile_test.go
@@ -1,13 +1,32 @@
 package topology_test
 
 import (
+	"errors"
 	"reflect"
+	"slices"
 	"testing"
 
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
 	clabernetescontrollerstopology "github.com/clabernetes/clabernetes/controllers/topology"
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 )
+
+func compileDefinitionWithOptions(
+	t *testing.T,
+	definition string,
+	options clabernetescontrollerstopology.CompileOptions,
+) (*clabernetescontrollerstopology.CompiledTopology, error) {
+	t.Helper()
+
+	topology := &clabernetesapisv1alpha1.Topology{}
+	topology.Spec.Definition.Containerlab = definition
+
+	return clabernetescontrollerstopology.CompileTopologyWithOptions(
+		&claberneteslogging.FakeInstance{},
+		topology,
+		options,
+	)
+}
 
 const flattenTestDefinition = `
 name: flatten-test
@@ -210,5 +229,145 @@ func TestCompileContainerlabLinks(t *testing.T) {
 
 	if !reflect.DeepEqual(compiled.Links, expected) {
 		t.Fatalf("expected links %+v, got %+v", expected, compiled.Links)
+	}
+}
+
+func TestCompileTopologyStrictRejectsLossyCompatibility(t *testing.T) {
+	definition := `
+name: strict-test
+mgmt:
+  ipv4-subnet: 172.30.30.0/24
+topology:
+  nodes:
+    n1:
+      kind: linux
+      image: ghcr.io/srl-labs/network-multitool
+      cpu: 2
+      ports: [22022:22/tcp]
+  links:
+    - endpoints: ["n1:eth1", "host:veth-review"]
+      labels: {purpose: review}
+      vars: {delay: 10}
+`
+
+	// The compatibility controller remains permissive.
+	topology := &clabernetesapisv1alpha1.Topology{}
+	topology.Spec.Definition.Containerlab = definition
+
+	_, err := clabernetescontrollerstopology.CompileTopology(
+		&claberneteslogging.FakeInstance{},
+		topology,
+	)
+	if err != nil {
+		t.Fatalf("warning policy unexpectedly rejected topology: %s", err)
+	}
+
+	_, err = compileDefinitionWithOptions(
+		t,
+		definition,
+		clabernetescontrollerstopology.CompileOptions{
+			UnsupportedFieldPolicy: clabernetescontrollerstopology.UnsupportedFieldPolicyError,
+		},
+	)
+	if err == nil {
+		t.Fatal("strict compilation accepted lossy topology")
+	}
+
+	unsupported := &clabernetescontrollerstopology.UnsupportedFeaturesError{}
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected UnsupportedFeaturesError, got %T: %s", err, err)
+	}
+
+	codes := make([]string, 0, len(unsupported.Diagnostics))
+	for _, diagnostic := range unsupported.Diagnostics {
+		codes = append(codes, diagnostic.Code)
+	}
+
+	for _, expected := range []string{
+		"host-port-pinning",
+		"management-network-semantics",
+		"unsupported-field",
+		"unsupported-link-labels",
+		"unsupported-link-vars",
+	} {
+		if !slices.Contains(codes, expected) {
+			t.Errorf("expected diagnostic %q, got %v", expected, codes)
+		}
+	}
+}
+
+func TestCompileTopologyAlwaysRejectsImpossibleStructures(t *testing.T) {
+	tests := map[string]string{
+		"bridge pseudo node": `
+name: bridge-test
+topology:
+  nodes:
+    br0: {kind: bridge}
+`,
+		"mgmt endpoint": `
+name: mgmt-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+  links:
+    - endpoints: ["n1:eth1", "mgmt-net:n1-eth1"]
+`,
+		"missing node": `
+name: missing-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+  links:
+    - endpoints: ["n1:eth1", "n2:eth1"]
+`,
+		"explicit vxlan": `
+name: vxlan-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+  links:
+    - type: vxlan
+      remote: 192.0.2.1
+      endpoint: {node: n1, interface: eth1}
+`,
+		"host network mode": `
+name: host-network-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine, network-mode: host}
+`,
+		"missing network mode primary": `
+name: missing-primary-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine, network-mode: container:missing}
+`,
+		"network mode cycle": `
+name: cycle-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine, network-mode: container:n2}
+    n2: {kind: linux, image: alpine, network-mode: container:n1}
+`,
+	}
+
+	for name, definition := range tests {
+		t.Run(name, func(t *testing.T) {
+			topology := &clabernetesapisv1alpha1.Topology{}
+			topology.Spec.Definition.Containerlab = definition
+
+			_, err := clabernetescontrollerstopology.CompileTopology(
+				&claberneteslogging.FakeInstance{},
+				topology,
+			)
+			if err == nil {
+				t.Fatal("warning policy accepted structurally unsupported topology")
+			}
+
+			unsupported := &clabernetescontrollerstopology.UnsupportedFeaturesError{}
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("expected UnsupportedFeaturesError, got %T: %s", err, err)
+			}
+		})
 	}
 }

--- a/controllers/topology/compile_test.go
+++ b/controllers/topology/compile_test.go
@@ -11,6 +11,16 @@ import (
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 )
 
+type warningRecordingLogger struct {
+	claberneteslogging.FakeInstance
+
+	warnings []string
+}
+
+func (l *warningRecordingLogger) Warn(message string) {
+	l.warnings = append(l.warnings, message)
+}
+
 func compileDefinitionWithOptions(
 	t *testing.T,
 	definition string,
@@ -296,6 +306,37 @@ topology:
 	}
 }
 
+func TestCompileTopologyWarningsIncludeLocations(t *testing.T) {
+	definition := `
+name: warning-locations
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+    n2: {kind: linux, image: alpine}
+  links:
+    - endpoints: ["n1:eth1", "n2:eth1"]
+      labels: {purpose: first}
+    - endpoints: ["n1:eth2", "n2:eth2"]
+      vars: {purpose: second}
+`
+	topology := &clabernetesapisv1alpha1.Topology{}
+	topology.Spec.Definition.Containerlab = definition
+	logger := &warningRecordingLogger{}
+
+	_, err := clabernetescontrollerstopology.CompileTopology(logger, topology)
+	if err != nil {
+		t.Fatalf("warning policy unexpectedly rejected topology: %s", err)
+	}
+
+	want := []string{
+		"topology.links[0].labels: link labels are not preserved by the c9s Link API",
+		"topology.links[1].vars: link vars are not preserved by the c9s Link API",
+	}
+	if !reflect.DeepEqual(logger.warnings, want) {
+		t.Fatalf("warnings = %q, want %q", logger.warnings, want)
+	}
+}
+
 func TestCompileTopologyAlwaysRejectsImpossibleStructures(t *testing.T) {
 	tests := map[string]string{
 		"bridge pseudo node": `
@@ -329,6 +370,25 @@ topology:
     - type: vxlan
       remote: 192.0.2.1
       endpoint: {node: n1, interface: eth1}
+`,
+		"explicit veth with brief endpoints": `
+name: explicit-veth-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+    n2: {kind: linux, image: alpine}
+  links:
+    - type: veth
+      endpoints: ["n1:eth1", "n2:eth1"]
+`,
+		"explicit host with brief endpoints": `
+name: explicit-host-test
+topology:
+  nodes:
+    n1: {kind: linux, image: alpine}
+  links:
+    - type: host
+      endpoints: ["n1:eth1", "host:veth-n1"]
 `,
 		"host network mode": `
 name: host-network-test

--- a/controllers/topology/compilecontainerlab.go
+++ b/controllers/topology/compilecontainerlab.go
@@ -435,16 +435,9 @@ func compileContainerlabLinks( //nolint:gocyclo
 		}
 
 		switch link.Type {
-		case "", "brief", "veth", "host":
+		case "", "brief":
 		default:
-			diagnostics.add(CompilerDiagnostic{
-				Code: "unsupported-link-type",
-				Path: linkPath + ".type",
-				Message: fmt.Sprintf(
-					"native link type %q has no c9s topology-link equivalent",
-					link.Type,
-				),
-			}, true)
+			diagnostics.add(unsupportedContainerlabLinkTypeDiagnostic(link.Type, linkPath), true)
 
 			continue
 		}
@@ -533,4 +526,25 @@ func compileContainerlabLinks( //nolint:gocyclo
 	}
 
 	return links, nil
+}
+
+func unsupportedContainerlabLinkTypeDiagnostic(linkType, linkPath string) CompilerDiagnostic {
+	message := fmt.Sprintf(
+		"native link type %q has no c9s topology-link equivalent",
+		linkType,
+	)
+
+	if linkType == "veth" || linkType == "host" {
+		message = fmt.Sprintf(
+			"explicit native link type %q requires structured endpoints that the "+
+				"c9s topology compiler does not support; use brief endpoints",
+			linkType,
+		)
+	}
+
+	return CompilerDiagnostic{
+		Code:    "unsupported-link-type",
+		Path:    linkPath + ".type",
+		Message: message,
+	}
 }

--- a/controllers/topology/compilecontainerlab.go
+++ b/controllers/topology/compilecontainerlab.go
@@ -3,6 +3,9 @@ package topology
 import (
 	"fmt"
 	"maps"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	clabernetesapis "github.com/clabernetes/clabernetes/apis"
@@ -15,12 +18,15 @@ import (
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
+const unknownFieldMatchCount = 3
+
 // compileContainerlabDefinition compiles a containerlab topology definition: every node gets
 // the topology defaults and its kind expanded *into* its definition (so the emitted Node
 // objects are self contained), and the links section becomes the compiled wire list.
 func compileContainerlabDefinition(
 	logger claberneteslogging.Instance,
 	definition string,
+	diagnostics *compileDiagnostics,
 ) (*CompiledTopology, error) {
 	containerlabConfig, unknownFields, err := clabernetesutilcontainerlab.LoadContainerlabConfig(
 		definition,
@@ -32,7 +38,16 @@ func compileContainerlabDefinition(
 	}
 
 	for _, unknownField := range unknownFields {
-		logger.Warn(unknownField)
+		diagnostics.add(diagnosticFromUnknownField(unknownField), false)
+	}
+
+	if containerlabConfig.Mgmt != nil {
+		diagnostics.add(CompilerDiagnostic{
+			Code: "management-network-semantics",
+			Path: "mgmt",
+			Message: "topology-level management network settings are launcher-local in c9s and " +
+				"do not create a shared cross-pod management network",
+		}, false)
 	}
 
 	compiled := &CompiledTopology{
@@ -44,7 +59,14 @@ func compileContainerlabDefinition(
 		Mgmt: containerlabConfig.Mgmt,
 	}
 
+	nodeNames := make([]string, 0, len(containerlabConfig.Topology.Nodes))
 	for nodeName := range containerlabConfig.Topology.Nodes {
+		nodeNames = append(nodeNames, nodeName)
+	}
+
+	sort.Strings(nodeNames)
+
+	for _, nodeName := range nodeNames {
 		compiled.Nodes[nodeName], err = flattenNodeDefinition(
 			containerlabConfig.Topology,
 			nodeName,
@@ -53,25 +75,149 @@ func compileContainerlabDefinition(
 			return nil, err
 		}
 
-		normalizeNodePorts(logger, nodeName, compiled.Nodes[nodeName])
-		dropUnusableNodeLabels(logger, nodeName, compiled.Nodes[nodeName])
+		normalizeNodePorts(diagnostics, nodeName, compiled.Nodes[nodeName])
+		dropUnusableNodeLabels(diagnostics, nodeName, compiled.Nodes[nodeName])
+
+		switch compiled.Nodes[nodeName].Kind {
+		case "bridge", "ovs-bridge", "host":
+			diagnostics.add(CompilerDiagnostic{
+				Code: "unsupported-pseudo-node",
+				Path: fmt.Sprintf("topology.nodes.%s.kind", nodeName),
+				Message: fmt.Sprintf(
+					"node %q uses native pseudo-node kind %q, which has no c9s "+
+						"launcher implementation",
+					nodeName,
+					compiled.Nodes[nodeName].Kind,
+				),
+			}, true)
+		}
 	}
 
-	compiled.Links, err = compileContainerlabLinks(containerlabConfig)
+	validateNodeNetworkModes(compiled.Nodes, diagnostics)
+
+	compiled.Links, err = compileContainerlabLinks(containerlabConfig, diagnostics)
 	if err != nil {
 		logger.Criticalf("failed compiling containerlab links, error: %s", err)
 
 		return nil, err
 	}
 
+	diagnosticErr := diagnostics.err()
+	if diagnosticErr != nil {
+		return nil, diagnosticErr
+	}
+
 	return compiled, nil
+}
+
+// validateNodeNetworkModes mirrors the Node CRD's container:<primary> contract in the compiler
+// and additionally verifies references and cycles that the single-object CRD cannot see. This is
+// required for strict, API-free validation and dry-run: callers must not need to create a Node
+// before learning that a native host/none mode or an impossible launcher group is unsupported.
+func validateNodeNetworkModes(
+	nodes map[string]*clabernetesutilcontainerlab.NodeDefinition,
+	diagnostics *compileDiagnostics,
+) {
+	nodeNames := make([]string, 0, len(nodes))
+	for nodeName := range nodes {
+		nodeNames = append(nodeNames, nodeName)
+	}
+
+	sort.Strings(nodeNames)
+
+	for _, nodeName := range nodeNames {
+		networkMode := nodes[nodeName].NetworkMode
+		if networkMode == "" {
+			continue
+		}
+
+		primary := clabernetesutilcontainerlab.ParseNetworkModeContainer(networkMode)
+
+		path := fmt.Sprintf("topology.nodes.%s.network-mode", nodeName)
+		if primary == "" || len(k8svalidation.IsDNS1123Label(primary)) != 0 {
+			diagnostics.add(CompilerDiagnostic{
+				Code: "unsupported-network-mode",
+				Path: path,
+				Message: fmt.Sprintf(
+					"node %q network-mode %q is unsupported; "+
+						"c9s accepts only container:<primary node name>",
+					nodeName,
+					networkMode,
+				),
+			}, true)
+
+			continue
+		}
+
+		if _, exists := nodes[primary]; !exists {
+			diagnostics.add(CompilerDiagnostic{
+				Code: "unknown-network-mode-primary",
+				Path: path,
+				Message: fmt.Sprintf(
+					"node %q shares a launcher with nonexistent primary node %q",
+					nodeName,
+					primary,
+				),
+			}, true)
+
+			continue
+		}
+
+		seen := map[string]bool{nodeName: true}
+
+		current := primary
+		for current != "" {
+			if seen[current] {
+				diagnostics.add(CompilerDiagnostic{
+					Code: "network-mode-cycle",
+					Path: path,
+					Message: fmt.Sprintf(
+						"node %q network-mode participates in a launcher-group cycle",
+						nodeName,
+					),
+				}, true)
+
+				break
+			}
+
+			seen[current] = true
+
+			nextNode, exists := nodes[current]
+			if !exists {
+				break
+			}
+
+			current = clabernetesutilcontainerlab.ParseNetworkModeContainer(
+				nextNode.NetworkMode,
+			)
+		}
+	}
+}
+
+var unknownFieldPattern = regexp.MustCompile(`^line (\d+): field ([^ ]+)`)
+
+func diagnosticFromUnknownField(message string) CompilerDiagnostic {
+	diagnostic := CompilerDiagnostic{
+		Code:    "unsupported-field",
+		Message: message,
+	}
+
+	matches := unknownFieldPattern.FindStringSubmatch(message)
+	if len(matches) != unknownFieldMatchCount {
+		return diagnostic
+	}
+
+	diagnostic.Line, _ = strconv.Atoi(matches[1])
+	diagnostic.Path = matches[2]
+
+	return diagnostic
 }
 
 // normalizeNodePorts rewrites the docker style "host:container" port entries that pasted
 // containerlab topologies carry into the destination-only form Nodes accept -- the pod side port
 // is an allocation clabernetes owns, so a pinned host side cannot be honored.
 func normalizeNodePorts(
-	logger claberneteslogging.Instance,
+	diagnostics *compileDiagnostics,
 	nodeName string,
 	nodeDefinition *clabernetesutilcontainerlab.NodeDefinition,
 ) {
@@ -81,13 +227,15 @@ func normalizeNodePorts(
 			continue
 		}
 
-		logger.Warnf(
-			"node %q port %q declares a host side port, which clabernetes allocates itself --"+
-				" using destination port %q instead",
-			nodeName,
-			portDefinition,
-			normalized,
-		)
+		diagnostics.add(CompilerDiagnostic{
+			Code: "host-port-pinning",
+			Path: fmt.Sprintf("topology.nodes.%s.ports[%d]", nodeName, idx),
+			Message: fmt.Sprintf(
+				"node %q port %q pins a host-side port, but c9s allocates launcher ports",
+				nodeName,
+				portDefinition,
+			),
+		}, false)
 
 		nodeDefinition.Ports[idx] = normalized
 	}
@@ -99,7 +247,7 @@ func normalizeNodePorts(
 // rejected on create. clabernetes' own namespace and the individual keys its controllers reserve
 // stay off limits too, since those labels carry meaning to reconciliation and selectors.
 func dropUnusableNodeLabels(
-	logger claberneteslogging.Instance,
+	diagnostics *compileDiagnostics,
 	nodeName string,
 	nodeDefinition *clabernetesutilcontainerlab.NodeDefinition,
 ) {
@@ -121,12 +269,16 @@ func dropUnusableNodeLabels(
 			reason = strings.Join(problems, "; ")
 		}
 
-		logger.Warnf(
-			"node %q label %q cannot become a kubernetes label and was omitted -- %s",
-			nodeName,
-			key,
-			reason,
-		)
+		diagnostics.add(CompilerDiagnostic{
+			Code: "unusable-node-label",
+			Path: fmt.Sprintf("topology.nodes.%s.labels.%s", nodeName, key),
+			Message: fmt.Sprintf(
+				"node %q label %q cannot become a Kubernetes label and would be omitted: %s",
+				nodeName,
+				key,
+				reason,
+			),
+		}, false)
 
 		delete(nodeDefinition.Labels, key)
 	}
@@ -258,12 +410,45 @@ func mergeSlices(base, layer []string) []string {
 }
 
 // compileContainerlabLinks converts the containerlab links section into compiled wires.
-func compileContainerlabLinks(
+func compileContainerlabLinks( //nolint:gocyclo
 	containerlabConfig *clabernetesutilcontainerlab.Config,
+	diagnostics *compileDiagnostics,
 ) ([]CompiledLink, error) {
 	links := make([]CompiledLink, 0, len(containerlabConfig.Topology.Links))
 
-	for _, link := range containerlabConfig.Topology.Links {
+	for linkIndex, link := range containerlabConfig.Topology.Links {
+		linkPath := fmt.Sprintf("topology.links[%d]", linkIndex)
+		if len(link.Labels) != 0 {
+			diagnostics.add(CompilerDiagnostic{
+				Code:    "unsupported-link-labels",
+				Path:    linkPath + ".labels",
+				Message: "link labels are not preserved by the c9s Link API",
+			}, false)
+		}
+
+		if len(link.Vars) != 0 {
+			diagnostics.add(CompilerDiagnostic{
+				Code:    "unsupported-link-vars",
+				Path:    linkPath + ".vars",
+				Message: "link vars are not preserved by the c9s Link API",
+			}, false)
+		}
+
+		switch link.Type {
+		case "", "brief", "veth", "host":
+		default:
+			diagnostics.add(CompilerDiagnostic{
+				Code: "unsupported-link-type",
+				Path: linkPath + ".type",
+				Message: fmt.Sprintf(
+					"native link type %q has no c9s topology-link equivalent",
+					link.Type,
+				),
+			}, true)
+
+			continue
+		}
+
 		if len(link.Endpoints) != clabernetesapisv1alpha1.LinkEndpointElementCount {
 			return nil, fmt.Errorf(
 				"%w: endpoint '%q' has wrong syntax, unexpected number of items",
@@ -282,6 +467,56 @@ func compileContainerlabLinks(
 				claberneteserrors.ErrParse,
 				link.Endpoints,
 			)
+		}
+
+		invalidEndpoint := false
+
+		for endpointIndex, endpointParts := range [][]string{endpointAParts, endpointBParts} {
+			nodeName := endpointParts[0]
+
+			if nodeName == clabernetesapisv1alpha1.LinkHostNodeName {
+				continue
+			}
+
+			if nodeName == "mgmt-net" || nodeName == "macvlan" {
+				diagnostics.add(CompilerDiagnostic{
+					Code: "unsupported-special-endpoint",
+					Path: fmt.Sprintf("%s.endpoints[%d]", linkPath, endpointIndex),
+					Message: fmt.Sprintf(
+						"special endpoint %q requires host networking that c9s does not provide",
+						nodeName,
+					),
+				}, true)
+
+				invalidEndpoint = true
+
+				continue
+			}
+
+			if _, exists := containerlabConfig.Topology.Nodes[nodeName]; !exists {
+				diagnostics.add(CompilerDiagnostic{
+					Code:    "unknown-link-endpoint",
+					Path:    fmt.Sprintf("%s.endpoints[%d]", linkPath, endpointIndex),
+					Message: fmt.Sprintf("link endpoint references nonexistent node %q", nodeName),
+				}, true)
+
+				invalidEndpoint = true
+			}
+		}
+
+		if endpointAParts[0] == clabernetesapisv1alpha1.LinkHostNodeName &&
+			endpointBParts[0] == clabernetesapisv1alpha1.LinkHostNodeName {
+			diagnostics.add(CompilerDiagnostic{
+				Code:    "invalid-host-link",
+				Path:    linkPath + ".endpoints",
+				Message: "a c9s host link must have exactly one Node endpoint",
+			}, true)
+
+			invalidEndpoint = true
+		}
+
+		if invalidEndpoint {
+			continue
 		}
 
 		links = append(links, CompiledLink{

--- a/controllers/topology/controller.go
+++ b/controllers/topology/controller.go
@@ -40,6 +40,7 @@ func NewController(
 		reconciler: NewReconciler(
 			baseController.Log,
 			baseController.Client,
+			clabernetes.GetCtrlRuntimeMgr().GetAPIReader(),
 			clabernetesconfig.GetManager,
 		),
 	}

--- a/controllers/topology/reconcile.go
+++ b/controllers/topology/reconcile.go
@@ -27,18 +27,21 @@ type Reconciler struct {
 	Client ctrlruntimeclient.Client
 
 	configManagerGetter clabernetesconfig.ManagerGetterFunc
+	apiReader           ctrlruntimeclient.Reader
 }
 
 // NewReconciler creates a new topology Reconciler.
 func NewReconciler(
 	log claberneteslogging.Instance,
 	client ctrlruntimeclient.Client,
+	apiReader ctrlruntimeclient.Reader,
 	configManagerGetter clabernetesconfig.ManagerGetterFunc,
 ) *Reconciler {
 	return &Reconciler{
 		Log:                 log,
 		Client:              client,
 		configManagerGetter: configManagerGetter,
+		apiReader:           apiReader,
 	}
 }
 

--- a/controllers/topology/status.go
+++ b/controllers/topology/status.go
@@ -87,13 +87,18 @@ func (r *Reconciler) updateTopologyStatus(
 	}
 
 	key := ctrlruntimeclient.ObjectKeyFromObject(topology)
+	reader := r.apiReader
+
+	if reader == nil {
+		reader = r.Client
+	}
 
 	var updated *clabernetesapisv1alpha1.Topology
 
 	err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
 		current := &clabernetesapisv1alpha1.Topology{}
 
-		err := r.Client.Get(ctx, key, current)
+		err := reader.Get(ctx, key, current)
 		if err != nil {
 			return err
 		}

--- a/controllers/topology/status.go
+++ b/controllers/topology/status.go
@@ -8,6 +8,7 @@ import (
 	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
 	apimachinerymeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientretry "k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,13 +74,51 @@ func (r *Reconciler) reconcileStatus(
 		})
 	}
 
-	if reflect.DeepEqual(topology.Status, desiredStatus) {
+	return r.updateTopologyStatus(ctx, topology, &desiredStatus)
+}
+
+func (r *Reconciler) updateTopologyStatus(
+	ctx context.Context,
+	topology *clabernetesapisv1alpha1.Topology,
+	desiredStatus *clabernetesapisv1alpha1.TopologyStatus,
+) error {
+	if reflect.DeepEqual(topology.Status, *desiredStatus) {
 		return nil
 	}
 
-	topology.Status = desiredStatus
+	key := ctrlruntimeclient.ObjectKeyFromObject(topology)
 
-	return r.Client.Update(ctx, topology)
+	var updated *clabernetesapisv1alpha1.Topology
+
+	err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+		current := &clabernetesapisv1alpha1.Topology{}
+
+		err := r.Client.Get(ctx, key, current)
+		if err != nil {
+			return err
+		}
+
+		if reflect.DeepEqual(current.Status, *desiredStatus) {
+			updated = current
+
+			return nil
+		}
+
+		current.Status = *desiredStatus
+
+		updateErr := r.Client.Update(ctx, current)
+		if updateErr == nil {
+			updated = current
+		}
+
+		return updateErr
+	})
+	if err == nil && updated != nil {
+		topology.Status = updated.Status
+		topology.SetResourceVersion(updated.GetResourceVersion())
+	}
+
+	return err
 }
 
 // resolveTopologyState derives the high level lifecycle state from the readiness counts and the

--- a/controllers/topology/status_test.go
+++ b/controllers/topology/status_test.go
@@ -3,6 +3,7 @@ package topology //nolint:testpackage // tests exercise bounded aggregate status
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,11 +12,84 @@ import (
 	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+type topologyConflictOnceClient struct {
+	ctrlruntimeclient.Client
+
+	updateCalls int
+}
+
+var errInjectedTopologyConflict = errors.New("injected conflict")
+
+func (c *topologyConflictOnceClient) Update(
+	ctx context.Context,
+	obj ctrlruntimeclient.Object,
+	opts ...ctrlruntimeclient.UpdateOption,
+) error {
+	c.updateCalls++
+	if c.updateCalls == 1 {
+		return apimachineryerrors.NewConflict(
+			apimachineryschema.GroupResource{Group: "c9s.run", Resource: "topologies"},
+			obj.GetName(),
+			errInjectedTopologyConflict,
+		)
+	}
+
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
+	t.Parallel()
+
+	scheme := apimachineryruntime.NewScheme()
+
+	err := clabernetesapisv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topology := &clabernetesapisv1alpha1.Topology{ObjectMeta: metav1.ObjectMeta{
+		Name: "retry-lab", Namespace: "clabernetes",
+	}}
+	baseClient := ctrlruntimefake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(topology).
+		Build()
+	client := &topologyConflictOnceClient{Client: baseClient}
+	reconciler := &Reconciler{Client: client}
+	desired := clabernetesapisv1alpha1.TopologyStatus{NodeCount: 2, ReadyNodeCount: 2}
+
+	err = reconciler.updateTopologyStatus(context.Background(), topology, &desired)
+	if err != nil {
+		t.Fatalf("updateTopologyStatus() failed after retryable conflict: %s", err)
+	}
+
+	if client.updateCalls != 2 {
+		t.Fatalf("status update calls = %d, want 2", client.updateCalls)
+	}
+
+	actual := &clabernetesapisv1alpha1.Topology{}
+
+	err = baseClient.Get(
+		context.Background(),
+		ctrlruntimeclient.ObjectKeyFromObject(topology),
+		actual,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual.Status.ReadyNodeCount != 2 {
+		t.Fatalf("stored ready node count = %d, want 2", actual.Status.ReadyNodeCount)
+	}
+}
 
 func TestReconcileStatusRemainsBounded(t *testing.T) {
 	scheme := apimachineryruntime.NewScheme()

--- a/controllers/topology/status_test.go
+++ b/controllers/topology/status_test.go
@@ -23,7 +23,8 @@ import (
 type topologyConflictOnceClient struct {
 	ctrlruntimeclient.Client
 
-	updateCalls int
+	updateCalls    int
+	beforeConflict func(context.Context, ctrlruntimeclient.Object) error
 }
 
 type countingTopologyReader struct {
@@ -52,6 +53,13 @@ func (c *topologyConflictOnceClient) Update(
 ) error {
 	c.updateCalls++
 	if c.updateCalls == 1 {
+		if c.beforeConflict != nil {
+			err := c.beforeConflict(ctx, obj)
+			if err != nil {
+				return err
+			}
+		}
+
 		return apimachineryerrors.NewConflict(
 			apimachineryschema.GroupResource{Group: "c9s.run", Resource: "topologies"},
 			obj.GetName(),
@@ -79,7 +87,21 @@ func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
 		WithScheme(scheme).
 		WithObjects(topology).
 		Build()
-	client := &topologyConflictOnceClient{Client: baseClient}
+	client := &topologyConflictOnceClient{
+		Client: baseClient,
+		beforeConflict: func(ctx context.Context, obj ctrlruntimeclient.Object) error {
+			current := &clabernetesapisv1alpha1.Topology{}
+
+			err := baseClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(obj), current)
+			if err != nil {
+				return err
+			}
+
+			current.Status.TopologyState = clabernetesapisv1alpha1.TopologyStateDegraded
+
+			return baseClient.Update(ctx, current)
+		},
+	}
 	apiReader := &countingTopologyReader{Reader: baseClient}
 	reconciler := &Reconciler{Client: client, apiReader: apiReader}
 	desired := clabernetesapisv1alpha1.TopologyStatus{NodeCount: 2, ReadyNodeCount: 2}

--- a/controllers/topology/status_test.go
+++ b/controllers/topology/status_test.go
@@ -26,6 +26,23 @@ type topologyConflictOnceClient struct {
 	updateCalls int
 }
 
+type countingTopologyReader struct {
+	ctrlruntimeclient.Reader
+
+	getCalls int
+}
+
+func (r *countingTopologyReader) Get(
+	ctx context.Context,
+	key ctrlruntimeclient.ObjectKey,
+	obj ctrlruntimeclient.Object,
+	opts ...ctrlruntimeclient.GetOption,
+) error {
+	r.getCalls++
+
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
 var errInjectedTopologyConflict = errors.New("injected conflict")
 
 func (c *topologyConflictOnceClient) Update(
@@ -63,7 +80,8 @@ func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
 		WithObjects(topology).
 		Build()
 	client := &topologyConflictOnceClient{Client: baseClient}
-	reconciler := &Reconciler{Client: client}
+	apiReader := &countingTopologyReader{Reader: baseClient}
+	reconciler := &Reconciler{Client: client, apiReader: apiReader}
 	desired := clabernetesapisv1alpha1.TopologyStatus{NodeCount: 2, ReadyNodeCount: 2}
 
 	err = reconciler.updateTopologyStatus(context.Background(), topology, &desired)
@@ -73,6 +91,10 @@ func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
 
 	if client.updateCalls != 2 {
 		t.Fatalf("status update calls = %d, want 2", client.updateCalls)
+	}
+
+	if apiReader.getCalls != 2 {
+		t.Fatalf("direct status reads = %d, want 2", apiReader.getCalls)
 	}
 
 	actual := &clabernetesapisv1alpha1.Topology{}

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -72,6 +72,12 @@ not an inheritance chain. Shared containerlab management-network settings tempor
 every generated LauncherProfile required by the Topology's Nodes; this is a compatibility bridge,
 not the final ownership model.
 
+Compilation is permissive for lossy fields that can be omitted: the controller emits the supported
+resources and logs warnings with source locations. It fails before resource creation when the
+definition cannot identify realizable c9s resources, including pseudo-nodes, special or unresolved
+endpoints, unsupported explicit link types, and invalid launcher groups. Strict diagnostics are
+available to library callers; `clabverter` does not currently expose a strict-mode flag.
+
 ### Launchers
 
 Each Node gets a Deployment running a single launcher container -- a Debian image with the
@@ -82,6 +88,12 @@ On startup the launcher fetches its own Node object (and those of any grouped no
 the Links terminating on them via field selectors, and verifies that link view against a
 digest annotation the node controller stamped on the pod. From that it materializes a
 containerlab topology file locally and runs plain containerlab.
+
+When status probes are enabled, the launcher checks every nested container in its group. Each must
+be running and not paused, restarting, or dead; an image-defined Docker healthcheck must also be
+healthy. The shared launcher status is therefore group-atomic. Optional TCP and SSH checks are
+additional application checks against the primary Node, while a running image without a
+healthcheck remains only process-level readiness.
 
 ### Inter-Node Connectivity
 

--- a/docs/crd/launcher-profile.mdx
+++ b/docs/crd/launcher-profile.mdx
@@ -7,4 +7,10 @@ icon: Settings2
 The `LauncherProfile` CRD holds reusable Kubernetes and launcher realization policy. Nodes
 reference profiles explicitly via `launcherProfileRef`.
 
+With `statusProbes.enabled`, readiness first requires the nested Docker container to be running
+and, when defined by the image, its Docker healthcheck to be `healthy`. A running image without a
+healthcheck provides process-level readiness only; configure an image healthcheck or an explicit
+TCP/SSH probe when application readiness matters. For grouped Nodes, generic readiness covers every
+member, while TCP/SSH checks remain scoped to the primary Node.
+
 <CrdViewer name="launcher-profile" />

--- a/launcher/clabernetes.go
+++ b/launcher/clabernetes.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -101,9 +102,10 @@ type clabernetes struct {
 	// containerIDs holds *all* ids of containers running --in theory we could have other side-car
 	// type stuff running so just catching all them here so we know if/when things fail
 	containerIDs []string
-	// meanwhile nodeContainerID is the container id of hte specific node this launcher represents
-	// -- meaning the single node from the original topology this launcher is representing
-	nodeContainerID string
+	// nodeContainerIDs maps every topology node hosted by this launcher to its nested Docker
+	// container. Readiness is group-atomic: the shared launcher pod is ready only when every
+	// member is ready.
+	nodeContainerIDs map[string]string
 
 	// initialTunnels holds the local tunnel view listed while materializing the topology -- the
 	// same snapshot seeds the connectivity manager so the tunnels it establishes line up with
@@ -248,9 +250,22 @@ func (c *clabernetes) launch() {
 		)
 	}
 
-	c.nodeContainerID, err = getContainerIDForNodeName(c.ctx, c.nodeName)
-	if err != nil {
-		c.logger.Fatalf("failed determining node %q container id, err: %s", c.nodeName, err)
+	c.nodeContainerIDs = make(map[string]string)
+
+	for _, member := range launcherGroupMembers(
+		c.nodeName,
+		os.Getenv(clabernetesconstants.LauncherGroupMembersEnv),
+	) {
+		containerID, lookupErr := getContainerIDForNodeName(c.ctx, member)
+		if lookupErr != nil {
+			c.logger.Fatalf("failed determining node %q container id, err: %s", member, lookupErr)
+		}
+
+		if containerID == "" {
+			c.logger.Fatalf("failed determining node %q container id: container not found", member)
+		}
+
+		c.nodeContainerIDs[member] = containerID
 	}
 
 	c.logger.Debug("containerlab launched successfully")
@@ -340,18 +355,24 @@ func (c *clabernetes) statusProbeConfiguration() (*statusProbeConfiguration, boo
 }
 
 func (c *clabernetes) getNodeReadiness(config *statusProbeConfiguration) bool {
-	containerReady, err := getContainerReadiness(c.ctx, c.nodeContainerID)
+	member, groupReady, err := getGroupContainerReadiness(
+		c.ctx,
+		c.nodeContainerIDs,
+		getContainerReadiness,
+	)
 	if err != nil {
 		c.logger.Warnf(
 			"failed determining node %q container readiness, error: %s",
-			c.nodeName,
+			member,
 			err,
 		)
 
 		return false
 	}
 
-	if !containerReady {
+	if !groupReady {
+		c.logger.Debugf("node %q container is not ready", member)
+
 		return false
 	}
 
@@ -362,7 +383,7 @@ func (c *clabernetes) getNodeReadiness(config *statusProbeConfiguration) bool {
 		return true
 	}
 
-	nodeAddr, err := getContainerAddr(c.ctx, c.nodeContainerID)
+	nodeAddr, err := getContainerAddr(c.ctx, c.nodeContainerIDs[c.nodeName])
 	if err != nil {
 		c.logger.Warnf(
 			"failed determining node %q address, error: %s",
@@ -383,6 +404,52 @@ func (c *clabernetes) getNodeReadiness(config *statusProbeConfiguration) bool {
 		config.sshUsername,
 		config.sshPassword,
 	)
+}
+
+func getGroupContainerReadiness(
+	ctx context.Context,
+	containerIDs map[string]string,
+	readiness func(context.Context, string) (bool, error),
+) (member string, ready bool, err error) {
+	for _, member = range sortedContainerNames(containerIDs) {
+		ready, err = readiness(ctx, containerIDs[member])
+		if err != nil || !ready {
+			return member, ready, err
+		}
+	}
+
+	return "", true, nil
+}
+
+func launcherGroupMembers(primary, secondaryCSV string) []string {
+	members := map[string]struct{}{}
+
+	for _, member := range append([]string{primary}, strings.Split(secondaryCSV, ",")...) {
+		member = strings.TrimSpace(member)
+		if member != "" {
+			members[member] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(members))
+	for member := range members {
+		result = append(result, member)
+	}
+
+	sort.Strings(result)
+
+	return result
+}
+
+func sortedContainerNames(containerIDs map[string]string) []string {
+	names := make([]string, 0, len(containerIDs))
+	for name := range containerIDs {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 func probeTCP(port int, nodeAddr string) bool {

--- a/launcher/clabernetes_test.go
+++ b/launcher/clabernetes_test.go
@@ -1,0 +1,59 @@
+package launcher //nolint:testpackage // tests exercise group readiness helpers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestLauncherGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	got := launcherGroupMembers("primary", "secondary-b, secondary-a,primary,,secondary-a")
+	want := []string{"primary", "secondary-a", "secondary-b"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("launcherGroupMembers() = %v, want %v", got, want)
+	}
+}
+
+func TestGetGroupContainerReadinessIncludesSecondaryNodes(t *testing.T) {
+	t.Parallel()
+
+	checked := []string{}
+
+	member, ready, err := getGroupContainerReadiness(
+		context.Background(),
+		map[string]string{"primary": "primary-id", "secondary": "secondary-id"},
+		func(_ context.Context, containerID string) (bool, error) {
+			checked = append(checked, containerID)
+
+			return containerID != "secondary-id", nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ready || member != "secondary" {
+		t.Fatalf("group readiness = (%q, %t), want secondary false", member, ready)
+	}
+
+	if !reflect.DeepEqual(checked, []string{"primary-id", "secondary-id"}) {
+		t.Fatalf("checked containers = %v, want primary and secondary", checked)
+	}
+}
+
+func TestSortedContainerNames(t *testing.T) {
+	t.Parallel()
+
+	got := sortedContainerNames(map[string]string{
+		"secondary": "container-b",
+		"primary":   "container-a",
+	})
+	want := []string{"primary", "secondary"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sortedContainerNames() = %v, want %v", got, want)
+	}
+}

--- a/launcher/docker.go
+++ b/launcher/docker.go
@@ -275,9 +275,10 @@ func getContainerIDForNodeName(ctx context.Context, nodeName string) (string, er
 		ctx,
 		"docker",
 		"ps",
+		"--all",
 		"--quiet",
 		"--filter",
-		fmt.Sprintf("name=%s", nodeName),
+		fmt.Sprintf("label=clab-node-name=%s", nodeName),
 	)
 
 	output, err := psCmd.Output()
@@ -285,7 +286,20 @@ func getContainerIDForNodeName(ctx context.Context, nodeName string) (string, er
 		return "", err
 	}
 
-	return strings.TrimSpace(string(output)), nil
+	containerIDs := strings.Fields(string(output))
+	if len(containerIDs) > 1 {
+		return "", fmt.Errorf(
+			"%w: found multiple containers for node %q",
+			claberneteserrors.ErrInvalidData,
+			nodeName,
+		)
+	}
+
+	if len(containerIDs) == 0 {
+		return "", nil
+	}
+
+	return containerIDs[0], nil
 }
 
 func getContainerAddr(ctx context.Context, containerID string) (string, error) {

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/design.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The Topology compiler is shared by the in-cluster compatibility controller and the clabverter
+conversion path. Its input vocabulary is native Containerlab, while the emitted resources and
+launcher pods support only a curated subset. Grouped Nodes share one launcher pod and one Docker
+network namespace, so a primary-only readiness check can report a broken group as healthy.
+
+## Goals
+
+- Preserve the existing permissive conversion behavior for fields that can be omitted without
+  making the emitted resources invalid.
+- Fail before resource creation when the source cannot identify realizable c9s Nodes or Links.
+- Make grouped generic readiness reflect the whole shared launcher.
+- Reduce status-update conflicts without introducing a new status API.
+- Give users actionable documentation for compatibility and readiness limits.
+
+## Decisions
+
+### 1. Separate lossy compatibility from impossible structures
+
+`CompileTopology` retains warning behavior for unknown fields, host-side port pinning, management
+network semantics, unusable labels, and link labels/vars, with the source path included in each
+warning. `CompileTopologyWithOptions` exposes an error policy that aggregates those diagnostics and
+sorts them by source path, line, code, and message. Pseudo-nodes, unresolved endpoints, special
+host-network endpoints, unsupported explicit link types, and invalid `network-mode` group references
+are errors under both policies. Explicit native `veth` and `host` link forms are rejected because
+their structured endpoint semantics are not represented by the c9s Link API; brief endpoint syntax
+remains supported.
+
+The strict policy is intentionally a reusable library surface rather than a new CLI contract:
+neither the in-cluster controller nor clabverter currently exposes a flag selecting it. Docs must
+not imply that `clabverter` already has a strict mode.
+
+### 2. Validate grouping as a topology-wide graph
+
+The compiler validates that every `container:<primary>` reference names a valid DNS label and an
+existing Node, then detects cycles. This complements the Node CRD's single-object validation and
+prevents an invalid group from being emitted and discovered only after reconciliation.
+
+### 3. Use Docker state for group-atomic readiness
+
+After deployment, the launcher resolves each primary and secondary by the stable
+`clab-node-name` Docker label, including stopped containers so a missing or stopped member is
+observable. Each member must be running, not paused/restarting/dead, and healthy when its image
+defines a Docker healthcheck. The shared status marker is healthy only when all members pass.
+Configured TCP/SSH probes still run against the primary address only.
+
+### 4. Retry status writes with a fresh resource version
+
+Node and Topology status updates retry on Kubernetes conflicts by fetching the current object through
+controller-runtime's uncached API reader before each attempt. If the desired status is already
+present, the retry is a no-op. Successful updates copy the current status and resource version back
+to the object used by the reconcile.
+
+## Risks and Review Constraints
+
+- Running without an image healthcheck remains process-level readiness; docs must recommend an
+  image healthcheck or explicit TCP/SSH probe when service readiness matters.
+- Docker label lookup with `--all` must not leave ambiguous duplicate containers for one node.
+- Node and Topology status are controller-owned, so retries intentionally replace the full status
+  with the controller's desired snapshot. If status ownership is ever split between controllers,
+  this must become field-scoped merging rather than a full replacement.
+- Compatibility-mode warnings now include source context, including link-label and link-variable
+  paths.
+
+## Verification
+
+- Existing PR unit, lint, image-build, and e2e checks remain green.
+- Add focused checks for duplicate/stopped Docker container discovery, grouped healthcheck and
+  lifecycle transitions, deterministic diagnostics, conflict retries, and compatibility warning
+  locations. Add a conflict test that changes stored status between retry attempts to verify the
+  uncached reader obtains a fresh resource version before the intentional full-status replacement.
+- Update architecture and release documentation, then run the docs build.

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/proposal.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+PR #290 adds runtime and compiler behavior without an OpenSpec change record. The current
+compiler can accept native Containerlab input while silently losing fields, and grouped launcher
+readiness only observes the primary nested container. Concurrent Node and Topology status writes
+also collide during rapid reconciliation. The latest PR commit narrows explicit link compatibility,
+adds source locations to warnings, and uses uncached API reads when retrying status writes.
+
+## What Changes
+
+- Define warning and strict compiler policies with deterministic structured diagnostics.
+- Continue warning for lossy compatibility fields with source locations, but reject structures that
+  cannot produce valid c9s resources under every policy.
+- Validate pseudo-nodes, special or unresolved link endpoints, invalid launcher-group network modes,
+  and explicit unsupported link types before emitting resources. Explicit native `veth` and `host`
+  link forms are rejected because their structured endpoints and semantics are not represented by
+  the c9s Link API; brief endpoints remain supported.
+- Make grouped launcher readiness atomic across every nested Docker container, including Docker
+  lifecycle and image-healthcheck state; keep application TCP/SSH checks on the primary node.
+- Retry Node and Topology status writes after resource-version conflicts using direct API reads
+  rather than a potentially stale informer cache.
+- Document compatibility warnings and failures, grouped readiness, healthcheck behavior, and the
+  limitations of process-level readiness.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `topology-resource`: compilation exposes compatibility diagnostics and rejects structurally
+  unrealizable source definitions.
+- `node-lifecycle`: grouped Nodes share an all-members generic readiness result.
+- `documentation-site`: public docs describe the new compiler and readiness contracts.
+
+## Impact
+
+The change affects the topology compiler, Node and Topology reconcilers, launcher Docker inspection,
+compiler and controller tests, OpenSpec requirements, and the architecture/release documentation.
+No new dependency or CRD field is required. The strict compiler policy is a library contract; this
+repository currently has no user-facing CLI flag that selects it. The current PR still contains no
+user-facing documentation files, so the documentation work remains outstanding.
+
+## Review Status
+
+The latest PR head passes lint, unit, e2e, try-smoke, and image checks. The uncached retry path and
+warning locations are covered by regression tests. Status replacement is intentionally full-object
+because Node and Topology status are controller-owned; the remaining verification is a conflict
+test that changes the stored object between retry attempts and proves the fresh resource version is
+used before replacement.
+
+## Non-goals
+
+- Supporting native host networking, bridge pseudo-nodes, `mgmt-net`, macvlan, or unsupported link
+  types inside c9s.
+- Inferring application readiness from ports, device kinds, or credentials.
+- Adding structured readiness failure reasons to Node status.

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/documentation-site/spec.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/documentation-site/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Runtime compatibility and readiness behavior is documented
+
+The user documentation SHALL explain that Topology compilation warns for lossy fields, fails for
+structurally unrealizable resources, and does not expose strict compilation as a clabverter CLI
+flag. It SHALL also explain that enabled grouped-node readiness is atomic across nested members,
+Docker image healthchecks are honored, process-level readiness is not application readiness, and
+TCP/SSH checks apply to the primary Node.
+
+#### Scenario: Reader diagnoses a rejected Topology
+
+- **WHEN** a reader consults the Topology or architecture documentation after a compilation failure
+- **THEN** the documentation identifies unsupported pseudo-nodes, special endpoints, unresolved endpoints, unsupported link types, and invalid grouping as fatal compatibility cases
+
+#### Scenario: Reader configures grouped readiness
+
+- **WHEN** a reader consults the Node or LauncherProfile documentation
+- **THEN** the documentation explains all-member readiness, Docker healthcheck requirements, process-level limitations, and primary-only TCP/SSH probes

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/node-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/node-lifecycle/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Enabled Node readiness reflects generic launcher state
+
+When status probes are enabled for a non-excluded Node, the launcher SHALL report readiness only
+when the represented nested Docker container is running and is not paused, restarting, or dead. If
+the nested image defines a Docker healthcheck, that healthcheck SHALL also report `healthy`.
+
+When multiple Nodes share one launcher through `network-mode: container:<primary>`, the launcher
+SHALL evaluate the generic nested-container readiness of every group member. The shared launcher
+Pod SHALL be ready only when all group members are ready; all member Nodes inherit that atomic
+group result. Application-specific TCP or SSH probes remain scoped to the primary Node.
+
+#### Scenario: Generic Node has no application-specific probe
+
+- **WHEN** a Node uses an enabled status-probe configuration without TCP or SSH settings
+- **THEN** its launcher Deployment renders startup and readiness probes and reports the generic nested-container readiness through the launcher status marker
+
+#### Scenario: Running container without a healthcheck
+
+- **WHEN** the represented nested container is running, not paused, not restarting, not dead, and has no Docker healthcheck
+- **THEN** the Node reports ready under the generic readiness contract
+
+#### Scenario: Nested container is not runnable
+
+- **WHEN** the represented nested container is stopped, paused, restarting, or dead
+- **THEN** the Node reports not ready
+
+#### Scenario: Grouped secondary container is not ready
+
+- **WHEN** a secondary nested container is paused, restarting, stopped, dead, or has an unhealthy image healthcheck while the primary remains healthy
+- **THEN** the shared launcher Pod and every Node in the launcher group report not ready
+
+#### Scenario: Image healthcheck is not healthy
+
+- **WHEN** the represented nested container is running but its Docker healthcheck is `starting` or `unhealthy`
+- **THEN** the Node reports not ready
+
+#### Scenario: Image healthcheck becomes healthy
+
+- **WHEN** a running nested container's Docker healthcheck reports `healthy`
+- **THEN** the generic readiness condition succeeds
+
+#### Scenario: Explicit application probe fails
+
+- **WHEN** the nested container satisfies the generic readiness contract but a configured TCP or SSH probe fails
+- **THEN** the Node remains not ready
+
+#### Scenario: Status probes are disabled or excluded
+
+- **WHEN** status probes are disabled for a Node or the Node is listed in `excludedNodes`
+- **THEN** the controller does not render launcher status probes for that Node
+
+## ADDED Requirements
+
+### Requirement: Node status updates tolerate resource-version conflicts
+
+The Node controller SHALL retry status writes after a resource-version conflict and SHALL avoid
+issuing an update when the current status already equals the desired status.
+
+#### Scenario: Node status races with a generated-resource update
+
+- **WHEN** a Node status write receives a resource-version conflict
+- **THEN** the controller refetches the current Node and retries without failing the reconcile solely because of the conflict

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/topology-resource/spec.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/specs/topology-resource/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: A source definition accepts native Containerlab vocabulary
+
+The compiler SHALL accept a Containerlab definition that carries node vocabulary c9s does not implement, so an existing working Containerlab topology can be used unchanged. Fields the compiler does not recognize MUST be omitted from the emitted resources, and each one MUST be reported as a warning naming the field and its location in the definition. Unrecognized vocabulary MUST NOT fail compilation.
+
+The compiler SHALL expose an unsupported-field policy. The compatibility Topology controller uses
+the warning policy above. Strict callers MAY select an error policy, in which case all otherwise
+lossy warnings are collected into deterministic structured diagnostics and compilation fails before
+resources are rendered. This allows a CLI runtime to share the compiler's capability matrix without
+silently changing topology semantics.
+
+A definition that is malformed, or that declares a recognized field with an unusable value, SHALL
+still fail compilation rather than have that field silently omitted. Structures that cannot
+identify realizable c9s resources, including external bridge/host pseudo-nodes, unresolved
+endpoint Nodes, `mgmt-net` or macvlan endpoints, and unsupported explicit link types, SHALL fail
+under every policy.
+
+#### Scenario: Compile a definition carrying unimplemented vocabulary
+
+- **WHEN** a Topology definition declares Containerlab node fields c9s does not implement
+- **THEN** compilation succeeds under the compatibility policy, emitted Nodes omit those fields, and each omitted field is reported as a warning naming it and where it appears
+
+#### Scenario: Strict caller rejects lossy compatibility
+
+- **WHEN** a strict caller compiles a definition containing unsupported fields, native management network settings, host-side port pinning, unusable labels, or link labels and vars that c9s cannot preserve
+- **THEN** compilation fails with deterministically sorted diagnostics naming every unsupported location
+
+#### Scenario: Structurally impossible input fails in compatibility mode
+
+- **WHEN** a definition references an external bridge, `mgmt-net`, macvlan, a nonexistent Node, an unsupported explicit link type, or an invalid launcher-group network mode
+- **THEN** compilation fails before generated resources are rendered
+
+## ADDED Requirements
+
+### Requirement: Topology status updates tolerate resource-version conflicts
+
+The Topology controller SHALL retry aggregate status writes after a resource-version conflict and SHALL
+avoid issuing an update when the current status already equals the desired status.
+
+#### Scenario: Topology status races with a spec update
+
+- **WHEN** a Topology status write receives a resource-version conflict
+- **THEN** the controller refetches the current Topology and retries without failing the reconcile solely because of the conflict

--- a/openspec/changes/archive/2026-08-12-harden-topology-compatibility/tasks.md
+++ b/openspec/changes/archive/2026-08-12-harden-topology-compatibility/tasks.md
@@ -1,0 +1,42 @@
+## 1. Compiler compatibility contract
+
+- [x] 1.1 Add warning and strict unsupported-field policies with typed diagnostics and stable
+  ordering.
+- [x] 1.2 Include source paths in compatibility warnings and preserve permissive omission for lossy
+  fields.
+- [x] 1.3 Make structurally impossible pseudo-nodes, endpoints, explicit link types, and network
+  modes fatal, including explicit native `veth` and `host` link forms.
+- [x] 1.4 Add compiler coverage for flattening, strict diagnostics, warning locations, impossible
+  structures, and deterministic output.
+
+## 2. Grouped launcher readiness
+
+- [x] 2.1 Resolve every launcher-group member by its Docker node label, including stopped members,
+  and reject ambiguous matches.
+- [x] 2.2 Require every member's Docker lifecycle state and image healthcheck to pass before
+  writing the shared healthy marker.
+- [x] 2.3 Keep application TCP/SSH probes scoped to the primary node and add helper coverage for
+  group membership and all-member readiness.
+
+## 3. Reconciliation reliability
+
+- [x] 3.1 Retry Node status writes after resource-version conflicts.
+- [x] 3.2 Retry Topology aggregate status writes after resource-version conflicts.
+- [x] 3.3 Verify retries read the latest server object before intentionally replacing the full
+  controller-owned status snapshot.
+
+## 4. Documentation
+
+- [x] 4.1 Explain Topology compatibility warnings, fatal structural validation, and the fact that
+  strict compilation is not currently exposed as a clabverter CLI flag.
+- [x] 4.2 Explain grouped readiness, Docker healthchecks, process-level readiness limitations, and
+  primary-only TCP/SSH checks in the architecture and LauncherProfile documentation.
+- [x] 4.3 Add the behavior change to the current release notes and verify direct page loads and
+  the production-like docs build.
+
+## 5. Final verification
+
+- [x] 5.1 Run the PR's focused unit tests, repository lint, and CI e2e/try-smoke checks.
+- [x] 5.2 Confirm the branch diff is whitespace-clean and has no existing review comments.
+- [x] 5.3 Explicitly accept controller-owned full-status replacement after testing a conflict that
+  changes the stored object between retry attempts.

--- a/openspec/specs/documentation-site/spec.md
+++ b/openspec/specs/documentation-site/spec.md
@@ -144,3 +144,21 @@ The repository SHALL document how maintainers configure Cloudflare and GitHub se
 
 - **WHEN** a maintainer follows the repository documentation for hosted documentation deployment
 - **THEN** they can identify the `clabernetes` Worker, the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets used by workflows, domain steps, and the workflows responsible for preview and production deploys
+
+### Requirement: Runtime compatibility and readiness behavior is documented
+
+The user documentation SHALL explain that Topology compilation warns for lossy fields, fails for
+structurally unrealizable resources, and does not expose strict compilation as a clabverter CLI
+flag. It SHALL also explain that enabled grouped-node readiness is atomic across nested members,
+Docker image healthchecks are honored, process-level readiness is not application readiness, and
+TCP/SSH checks apply to the primary Node.
+
+#### Scenario: Reader diagnoses a rejected Topology
+
+- **WHEN** a reader consults the Topology or architecture documentation after a compilation failure
+- **THEN** the documentation identifies unsupported pseudo-nodes, special endpoints, unresolved endpoints, unsupported link types, and invalid grouping as fatal compatibility cases
+
+#### Scenario: Reader configures grouped readiness
+
+- **WHEN** a reader consults the Node or LauncherProfile documentation
+- **THEN** the documentation explains all-member readiness, Docker healthcheck requirements, process-level limitations, and primary-only TCP/SSH probes

--- a/openspec/specs/node-lifecycle/spec.md
+++ b/openspec/specs/node-lifecycle/spec.md
@@ -254,3 +254,13 @@ A Node resource SHALL contain only its own definition, payload references, launc
 
 - **WHEN** additional Nodes and Links are added to the same lab
 - **THEN** the serialized size of an existing unchanged Node does not grow
+
+### Requirement: Node status updates tolerate resource-version conflicts
+
+The Node controller SHALL retry status writes after a resource-version conflict and SHALL avoid
+issuing an update when the current status already equals the desired status.
+
+#### Scenario: Node status races with a generated-resource update
+
+- **WHEN** a Node status write receives a resource-version conflict
+- **THEN** the controller refetches the current Node and retries without failing the reconcile solely because of the conflict

--- a/openspec/specs/node-lifecycle/spec.md
+++ b/openspec/specs/node-lifecycle/spec.md
@@ -196,6 +196,11 @@ When status probes are enabled for a non-excluded Node, the launcher SHALL repor
 when the represented nested Docker container is running and is not paused, restarting, or dead. If
 the nested image defines a Docker healthcheck, that healthcheck SHALL also report `healthy`.
 
+When multiple Nodes share one launcher through `network-mode: container:<primary>`, the launcher
+SHALL evaluate the generic nested-container readiness of every group member. The shared launcher
+Pod SHALL be ready only when all group members are ready; all member Nodes inherit that atomic
+group result. Application-specific TCP or SSH probes remain scoped to the primary Node.
+
 #### Scenario: Generic Node has no application-specific probe
 
 - **WHEN** a Node uses an enabled status-probe configuration without TCP or SSH settings
@@ -212,6 +217,12 @@ the nested image defines a Docker healthcheck, that healthcheck SHALL also repor
 
 - **WHEN** the represented nested container is stopped, paused, restarting, or dead
 - **THEN** the Node reports not ready
+
+#### Scenario: Grouped secondary container restarts
+
+- **WHEN** a secondary nested container is paused, restarting, stopped, dead, or has an unhealthy
+  image healthcheck while the primary remains healthy
+- **THEN** the shared launcher Pod and every Node in the launcher group report not ready
 
 #### Scenario: Image healthcheck is not healthy
 

--- a/openspec/specs/topology-resource/spec.md
+++ b/openspec/specs/topology-resource/spec.md
@@ -210,3 +210,13 @@ A label that Kubernetes would reject, or that is in the reserved `c9s.run/` name
 
 - **WHEN** a source topology node declares a valid label using a key such as `app.kubernetes.io/name` that c9s uses for identity or selection
 - **THEN** it is omitted with a warning, because user metadata must not overwrite controller invariants
+
+### Requirement: Topology status updates tolerate resource-version conflicts
+
+The Topology controller SHALL retry aggregate status writes after a resource-version conflict and SHALL
+avoid issuing an update when the current status already equals the desired status.
+
+#### Scenario: Topology status races with a spec update
+
+- **WHEN** a Topology status write receives a resource-version conflict
+- **THEN** the controller refetches the current Topology and retries without failing the reconcile solely because of the conflict

--- a/openspec/specs/topology-resource/spec.md
+++ b/openspec/specs/topology-resource/spec.md
@@ -131,7 +131,16 @@ The system SHALL document and support direct application of generated primitive 
 
 The compiler SHALL accept a Containerlab definition that carries node vocabulary c9s does not implement, so an existing working Containerlab topology can be used unchanged. Fields the compiler does not recognize MUST be omitted from the emitted resources, and each one MUST be reported as a warning naming the field and its location in the definition. Unrecognized vocabulary MUST NOT fail compilation.
 
+The compiler SHALL expose an unsupported-field policy. The compatibility Topology controller uses
+the warning policy above. Strict callers MAY select an error policy, in which case all otherwise
+lossy warnings are collected into deterministic structured diagnostics and compilation fails before
+resources are rendered. This allows a CLI runtime to share the compiler's capability matrix without
+silently changing topology semantics.
+
 A definition that is malformed, or that declares a recognized field with an unusable value, SHALL still fail compilation rather than have that field silently omitted.
+Structures that cannot identify realizable c9s resources, including external bridge/host pseudo
+nodes, unresolved endpoint Nodes, `mgmt-net` or macvlan endpoints, and unsupported explicit link
+types, SHALL fail under every policy.
 
 #### Scenario: Compile a definition carrying unimplemented vocabulary
 
@@ -147,6 +156,19 @@ A definition that is malformed, or that declares a recognized field with an unus
 
 - **WHEN** direct manifest generation runs against a definition carrying unimplemented vocabulary
 - **THEN** it reports the same omitted fields before the user applies anything
+
+#### Scenario: Strict caller rejects lossy compatibility
+
+- **WHEN** a strict caller compiles a definition containing unsupported fields, native management
+  network settings, host-side port pinning, unusable labels, or link labels and vars that c9s cannot
+  preserve
+- **THEN** compilation fails with sorted diagnostics naming every unsupported location
+
+#### Scenario: Structurally impossible link fails in compatibility mode
+
+- **WHEN** a definition references an external bridge, `mgmt-net`, macvlan, a nonexistent Node, or
+  an unsupported explicit link type
+- **THEN** compilation fails instead of creating resources that can only fail after deployment
 
 #### Scenario: Reject a recognized field holding an unusable value
 


### PR DESCRIPTION
## Summary

- add compiler policies and structured diagnostics for containerlab features that c9s cannot preserve
- reject structurally unsupported pseudo-nodes, special endpoints, link types, network modes, missing grouping primaries, and grouping cycles before launcher resources are created
- make launcher readiness group-atomic by checking every nested node container, including Docker restart and health states
- retry Node and Topology status writes on resource-version conflicts
- document the strict-runtime and compatibility-controller contracts

## Why

The compatibility Topology controller and the containerlab runtime use the same compiler but need different handling for lossy fields. The controller should continue accepting compatible definitions with warnings, while a runtime promising containerlab semantics must be able to fail before it mutates the cluster.

Grouped nodes also shared a Deployment status even though the readiness probe inspected only the primary nested container. A crash-looping secondary could therefore remain reported as Ready.

## Impact

Strict compiler callers now receive deterministic, typed diagnostics. The compatibility controller remains warning-based for lossy fields, while structures that cannot produce valid c9s resources fail under both policies. Launcher pods and every Node in a group become NotReady when any nested member stops, restarts, dies, or fails its image-defined healthcheck.

## Validation

- `make lint`
- `go test ./controllers/topology ./controllers/node ./launcher`
- live testing on a kind c9s cluster covering standalone readiness, grouped secondary restart loops, image healthchecks, strict compilation, compatibility warnings, impossible bridge rejection, rapid reconciliation, and recovery
