### PR TITLE
Add containerd registry hosts directory support

### DIFF
--- a/apis/v1alpha1/configspec.go
+++ b/apis/v1alpha1/configspec.go
@@ -124,6 +124,15 @@ type ConfigImagePull struct {
 	// +kubebuilder:validation:Enum=containerd
 	// +optional
 	CRIKindOverride string `json:"criKindOverride,omitempty"`
+	// CRIHostsDir is an optional host directory containing containerd registry hosts
+	// configuration. When set and the effective CRI is containerd, the directory is mounted
+	// read-only into pull-through launchers both at its original path (so certificate paths rooted
+	// in this directory remain valid) and at containerd's conventional certs.d path used by
+	// nerdctl.
+	// +kubebuilder:validation:Pattern=^/.+
+	// +kubebuilder:validation:XValidation:rule="self.matches('^/.*[^/].*$') && !self.matches('(^|/)[.][.]?(/|$)')",message="criHostsDir must be an absolute non-root path without '.' or '..' segments"
+	// +optional
+	CRIHostsDir string `json:"criHostsDir,omitempty"`
 	// DockerDaemonConfig allows for setting a default docker daemon config for launcher pods
 	// with the specified secret. The secret *must be present in the namespace of any given
 	// topology* -- so if you are configuring this at the "global config" level, ensure that you are

--- a/assets/crd/c9s.run_configs.yaml
+++ b/assets/crd/c9s.run_configs.yaml
@@ -428,6 +428,19 @@ spec:
                   ImagePull holds configurations relevant to how clabernetes launcher pods handle pulling
                   images.
                 properties:
+                  criHostsDir:
+                    description: |-
+                      CRIHostsDir is an optional host directory containing containerd registry hosts
+                      configuration. When set and the effective CRI is containerd, the directory is mounted
+                      read-only into pull-through launchers both at its original path (so certificate paths rooted
+                      in this directory remain valid) and at containerd's conventional certs.d path used by
+                      nerdctl.
+                    pattern: ^/.+
+                    type: string
+                    x-kubernetes-validations:
+                    - message: criHostsDir must be an absolute non-root path without
+                        '.' or '..' segments
+                      rule: self.matches('^/.*[^/].*$') && !self.matches('(^|/)[.][.]?(/|$)')
                   criKindOverride:
                     description: |-
                       CRIKindOverride allows for overriding the auto discovered cri flavor of the cluster -- this

--- a/charts/clabernetes/crds/c9s.run_configs.yaml
+++ b/charts/clabernetes/crds/c9s.run_configs.yaml
@@ -428,6 +428,19 @@ spec:
                   ImagePull holds configurations relevant to how clabernetes launcher pods handle pulling
                   images.
                 properties:
+                  criHostsDir:
+                    description: |-
+                      CRIHostsDir is an optional host directory containing containerd registry hosts
+                      configuration. When set and the effective CRI is containerd, the directory is mounted
+                      read-only into pull-through launchers both at its original path (so certificate paths rooted
+                      in this directory remain valid) and at containerd's conventional certs.d path used by
+                      nerdctl.
+                    pattern: ^/.+
+                    type: string
+                    x-kubernetes-validations:
+                    - message: criHostsDir must be an absolute non-root path without
+                        '.' or '..' segments
+                      rule: self.matches('^/.*[^/].*$') && !self.matches('(^|/)[.][.]?(/|$)')
                   criKindOverride:
                     description: |-
                       CRIKindOverride allows for overriding the auto discovered cri flavor of the cluster -- this

--- a/charts/clabernetes/templates/configmap.yaml
+++ b/charts/clabernetes/templates/configmap.yaml
@@ -58,6 +58,9 @@ data:
   {{- if .Values.globalConfig.imagePull.criKindOverride }}
   criKindOverride: {{ .Values.globalConfig.imagePull.criKindOverride }}
   {{- end }}
+  {{- if .Values.globalConfig.imagePull.criHostsDir }}
+  criHostsDir: {{ .Values.globalConfig.imagePull.criHostsDir | quote }}
+  {{- end }}
   naming: {{ .Values.globalConfig.naming }}
   {{- if .Values.globalConfig.deployment.extraEnv }}
   extraEnv: |-

--- a/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
@@ -5,6 +5,9 @@ globalTolerations: &globalTolerations
     operator: Equal
     value: "true"
     effect: PreferNoSchedule
+globalConfig:
+  imagePull:
+    criHostsDir: "/etc/cri/hosts #prod"
 manager:
   deploymentTolerations:
     - key: test_toleration_manager_only

--- a/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
@@ -7,7 +7,7 @@ globalTolerations: &globalTolerations
     effect: PreferNoSchedule
 globalConfig:
   imagePull:
-    criHostsDir: "/etc/cri/hosts #prod"
+    criHostsDir: "/etc/cri/hosts"
 manager:
   deploymentTolerations:
     - key: test_toleration_manager_only

--- a/charts/clabernetes/tests/customized_values/test-fixtures/golden/configmap.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/golden/configmap.yaml
@@ -38,5 +38,5 @@ data:
   imagePullThroughMode: auto
   launcherImagePullPolicy: IfNotPresent
   launcherLogLevel: info
-  criHostsDir: "/etc/cri/hosts #prod"
+  criHostsDir: "/etc/cri/hosts"
   naming: prefixed

--- a/charts/clabernetes/tests/customized_values/test-fixtures/golden/configmap.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/golden/configmap.yaml
@@ -38,4 +38,5 @@ data:
   imagePullThroughMode: auto
   launcherImagePullPolicy: IfNotPresent
   launcherLogLevel: info
+  criHostsDir: "/etc/cri/hosts #prod"
   naming: prefixed

--- a/charts/clabernetes/values.schema.json
+++ b/charts/clabernetes/values.schema.json
@@ -147,6 +147,16 @@
             "criKindOverride": {
               "type": "string",
               "enum": ["containerd"]
+            },
+            "criHostsDir": {
+              "type": "string",
+              "pattern": "^/.+",
+              "not": {
+                "anyOf": [
+                  {"pattern": "^/*$"},
+                  {"pattern": "(^|/)\\.\\.?(/|$)"}
+                ]
+              }
             }
           }
         },

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -107,6 +107,10 @@ globalConfig:
     # won't be needed often, but could come in handy in multi-cri clusters or if nodes for some
     # reason do not properly report their cri flavor (or we incorrectly parse it?!)
     # criKindOverride: ""
+    # criHostsDir optionally mounts a host directory containing containerd registry hosts
+    # configuration into pull-through launcher pods. The directory is also mounted at
+    # /etc/containerd/certs.d so nerdctl uses the same mirrors, certificates, and host settings.
+    # criHostsDir: ""
 
   deployment:
     # resourcesDefault hold the default resources to apply to clabernetes launcher pods.

--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -30,6 +30,7 @@ type bootstrapConfig struct {
 	launcherLogLevel            string
 	criSockOverride             string
 	criKindOverride             string
+	criHostsDir                 string
 	naming                      string
 	containerlabVersion         string
 	extraEnv                    []k8scorev1.EnvVar
@@ -154,6 +155,11 @@ func bootstrapFromConfigMap( //nolint:gocyclo,funlen,gocognit
 	criKindOverride, criKindOverrideOk := inMap["criKindOverride"]
 	if criKindOverrideOk {
 		bc.criKindOverride = criKindOverride
+	}
+
+	criHostsDir, criHostsDirOk := inMap["criHostsDir"]
+	if criHostsDirOk {
+		bc.criHostsDir = criHostsDir
 	}
 
 	naming, namingOk := inMap["naming"]
@@ -302,6 +308,10 @@ func mergeFromBootstrapConfigMerge( //nolint:gocyclo
 		config.Spec.ImagePull.CRIKindOverride = bootstrap.criKindOverride
 	}
 
+	if config.Spec.ImagePull.CRIHostsDir == "" {
+		config.Spec.ImagePull.CRIHostsDir = bootstrap.criHostsDir
+	}
+
 	if config.Spec.Naming == "" {
 		config.Spec.Naming = bootstrap.naming
 	}
@@ -329,6 +339,7 @@ func mergeFromBootstrapConfigReplace(
 			PullThroughOverride: bootstrap.imagePullThroughMode,
 			CRISockOverride:     bootstrap.criSockOverride,
 			CRIKindOverride:     bootstrap.criKindOverride,
+			CRIHostsDir:         bootstrap.criHostsDir,
 		},
 		Deployment: clabernetesapisv1alpha1.ConfigDeployment{
 			ResourcesDefault:            bootstrap.resourcesDefault,

--- a/config/bootstrap_test.go
+++ b/config/bootstrap_test.go
@@ -1,0 +1,81 @@
+package config_test
+
+import (
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
+	clabernetesconfig "github.com/clabernetes/clabernetes/config"
+	k8scorev1 "k8s.io/api/core/v1"
+)
+
+func TestMergeFromBootstrapConfigCRIHostsDir(t *testing.T) {
+	t.Parallel()
+
+	const bootstrapHostsDir = "/etc/cri/conf.d/hosts"
+
+	for _, tt := range []struct {
+		name           string
+		configCRExists bool
+		mergeMode      string
+		existing       string
+		want           string
+	}{
+		{
+			name: "new config uses bootstrap value",
+			want: bootstrapHostsDir,
+		},
+		{
+			name:           "merge fills empty value",
+			configCRExists: true,
+			want:           bootstrapHostsDir,
+		},
+		{
+			name:           "merge preserves existing value",
+			configCRExists: true,
+			existing:       "/etc/containerd/certs.d",
+			want:           "/etc/containerd/certs.d",
+		},
+		{
+			name:           "overwrite replaces existing value",
+			configCRExists: true,
+			mergeMode:      "overwrite",
+			existing:       "/etc/containerd/certs.d",
+			want:           bootstrapHostsDir,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bootstrapConfigMap := &k8scorev1.ConfigMap{
+				Data: map[string]string{
+					"criHostsDir": bootstrapHostsDir,
+					"mergeMode":   tt.mergeMode,
+				},
+			}
+			config := &clabernetesapisv1alpha1.Config{
+				Spec: clabernetesapisv1alpha1.ConfigSpec{
+					ImagePull: clabernetesapisv1alpha1.ConfigImagePull{
+						CRIHostsDir: tt.existing,
+					},
+				},
+			}
+
+			err := clabernetesconfig.MergeFromBootstrapConfig(
+				bootstrapConfigMap,
+				config,
+				tt.configCRExists,
+			)
+			if err != nil {
+				t.Fatalf("merge bootstrap config: %v", err)
+			}
+
+			if config.Spec.ImagePull.CRIHostsDir != tt.want {
+				t.Fatalf(
+					"expected CRI hosts directory %q, got %q",
+					tt.want,
+					config.Spec.ImagePull.CRIHostsDir,
+				)
+			}
+		})
+	}
+}

--- a/config/fake.go
+++ b/config/fake.go
@@ -16,6 +16,8 @@ func GetFakeManager() Manager {
 // fakeManager defined type alias to be used below.
 type fakeManager struct {
 	nodeSelectorsByImage map[string]map[string]string
+	criHostsDir          string
+	criKindOverride      string
 }
 
 // FakeOption defined type alias to be used below.
@@ -43,6 +45,20 @@ func WithNodeSelectors(selectors map[string]map[string]string) FakeOption {
 			maps.Copy(copiedSelectors, selectors)
 			fm.nodeSelectorsByImage[pattern] = copiedSelectors
 		}
+	}
+}
+
+// WithCRIHostsDir configures a CRI registry hosts directory on the fake manager.
+func WithCRIHostsDir(path string) FakeOption {
+	return func(fm *fakeManager) {
+		fm.criHostsDir = path
+	}
+}
+
+// WithCRIKindOverride configures a CRI kind override on the fake manager.
+func WithCRIKindOverride(kind string) FakeOption {
+	return func(fm *fakeManager) {
+		fm.criKindOverride = kind
 	}
 }
 
@@ -106,7 +122,11 @@ func (f fakeManager) GetImagePullCriSockOverride() string {
 }
 
 func (f fakeManager) GetImagePullCriKindOverride() string {
-	return ""
+	return f.criKindOverride
+}
+
+func (f fakeManager) GetImagePullCriHostsDir() string {
+	return f.criHostsDir
 }
 
 func (f fakeManager) GetDockerDaemonConfig() string {

--- a/config/get.go
+++ b/config/get.go
@@ -117,6 +117,13 @@ func (m *manager) GetImagePullCriKindOverride() string {
 	return m.config.ImagePull.CRIKindOverride
 }
 
+func (m *manager) GetImagePullCriHostsDir() string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.config.ImagePull.CRIHostsDir
+}
+
 func (m *manager) GetDockerDaemonConfig() string {
 	m.lock.RLock()
 	defer m.lock.RUnlock()

--- a/config/manager.go
+++ b/config/manager.go
@@ -138,6 +138,8 @@ type Manager interface { //nolint: interfacebloat
 	GetImagePullCriSockOverride() string
 	// GetImagePullCriKindOverride returns the cri kind override.
 	GetImagePullCriKindOverride() string
+	// GetImagePullCriHostsDir returns the host directory containing CRI registry configuration.
+	GetImagePullCriHostsDir() string
 	// GetDockerDaemonConfig returns the secret name to mount in /etc/docker -- the secret *must*
 	// have a key "daemon.json" so the final mounted file is /etc/docker/daemon.json.
 	GetDockerDaemonConfig() string

--- a/constants/kubernetes.go
+++ b/constants/kubernetes.go
@@ -38,6 +38,8 @@ const (
 	KubernetesCRISockContainerdPath = "/run/containerd"
 	// KubernetesCRISockContainerd is the containerd sock filename.
 	KubernetesCRISockContainerd = "containerd.sock"
+	// ContainerdCertsDir is the conventional registry hosts directory used by containerd clients.
+	ContainerdCertsDir = "/etc/containerd/certs.d"
 )
 
 const (

--- a/controllers/node/deployment.go
+++ b/controllers/node/deployment.go
@@ -363,6 +363,12 @@ func (r *DeploymentReconciler) renderDeploymentVolumes( //nolint:funlen
 		)
 	}
 
+	volumes, volumeMountsFromCommonSpec = r.renderDeploymentCRIHostsVolumes(
+		input.Profile,
+		volumes,
+		volumeMountsFromCommonSpec,
+	)
+
 	if input.Profile.DockerDaemonConfig != "" {
 		volumes = append(
 			volumes,
@@ -493,11 +499,86 @@ func (r *DeploymentReconciler) renderDeploymentVolumes( //nolint:funlen
 	return volumeMountsFromCommonSpec
 }
 
+func (r *DeploymentReconciler) effectiveCRIKind() string {
+	criKind := r.configManagerGetter().GetImagePullCriKindOverride()
+	if criKind != "" {
+		return criKind
+	}
+
+	return r.criKind
+}
+
+func (r *DeploymentReconciler) renderDeploymentCRIHostsVolumes(
+	profile *ResolvedProfile,
+	volumes []k8scorev1.Volume,
+	volumeMounts []k8scorev1.VolumeMount,
+) ([]k8scorev1.Volume, []k8scorev1.VolumeMount) {
+	configuredCRIHostsDir := r.configManagerGetter().GetImagePullCriHostsDir()
+	if profile.PullThroughOverride == clabernetesconstants.ImagePullThroughModeNever ||
+		configuredCRIHostsDir == "" ||
+		r.effectiveCRIKind() != clabernetesconstants.KubernetesCRIContainerd {
+		return volumes, volumeMounts
+	}
+
+	criHostsDir := filepath.Clean(configuredCRIHostsDir)
+	if !filepath.IsAbs(criHostsDir) || criHostsDir == string(filepath.Separator) {
+		r.log.Warnf("ignoring invalid CRI hosts directory %q", configuredCRIHostsDir)
+
+		return volumes, volumeMounts
+	}
+
+	volumes = append(
+		volumes,
+		k8scorev1.Volume{
+			Name: "cri-hosts",
+			VolumeSource: k8scorev1.VolumeSource{
+				HostPath: &k8scorev1.HostPathVolumeSource{
+					Path: criHostsDir,
+					Type: clabernetesutil.ToPointer(k8scorev1.HostPathDirectory),
+				},
+			},
+		},
+	)
+
+	volumeMounts = append(
+		volumeMounts,
+		k8scorev1.VolumeMount{
+			Name:      "cri-hosts",
+			ReadOnly:  true,
+			MountPath: criHostsDir,
+		},
+	)
+
+	if criHostsDir != clabernetesconstants.ContainerdCertsDir {
+		volumeMounts = append(
+			volumeMounts,
+			k8scorev1.VolumeMount{
+				Name:      "cri-hosts",
+				ReadOnly:  true,
+				MountPath: clabernetesconstants.ContainerdCertsDir,
+			},
+		)
+	}
+
+	return volumes, volumeMounts
+}
+
 func (r *DeploymentReconciler) renderDeploymentVolumesGetCRISockPath(
 	profile *ResolvedProfile,
 ) (path, subPath string) {
 	if profile.PullThroughOverride == clabernetesconstants.ImagePullThroughModeNever {
 		// image pull through is never, no cri sock needed
+		return path, subPath
+	}
+
+	criKind := r.effectiveCRIKind()
+	if criKind != clabernetesconstants.KubernetesCRIContainerd {
+		r.log.Warnf(
+			"image pull through mode is auto or always but cri kind is not containerd!"+
+				" got cri kind %q",
+			criKind,
+		)
+
 		return path, subPath
 	}
 
@@ -514,18 +595,9 @@ func (r *DeploymentReconciler) renderDeploymentVolumesGetCRISockPath(
 			return path, subPath
 		}
 	} else {
-		switch r.criKind {
-		case clabernetesconstants.KubernetesCRIContainerd:
-			path = clabernetesconstants.KubernetesCRISockContainerdPath
+		path = clabernetesconstants.KubernetesCRISockContainerdPath
 
-			subPath = clabernetesconstants.KubernetesCRISockContainerd
-		default:
-			r.log.Warnf(
-				"image pull through mode is auto or always but cri kind is not containerd!"+
-					" got cri kind %q",
-				r.criKind,
-			)
-		}
+		subPath = clabernetesconstants.KubernetesCRISockContainerd
 	}
 
 	return path, subPath
@@ -578,10 +650,7 @@ func (r *DeploymentReconciler) renderDeploymentContainerEnv( //nolint: funlen
 	nodeName := input.Node.GetName()
 	profile := input.Profile
 
-	criKind := r.configManagerGetter().GetImagePullCriKindOverride()
-	if criKind == "" {
-		criKind = r.criKind
-	}
+	criKind := r.effectiveCRIKind()
 
 	nodeImage := input.Node.Spec.Image
 	if nodeImage == "" {

--- a/controllers/node/deployment_test.go
+++ b/controllers/node/deployment_test.go
@@ -210,6 +210,252 @@ func TestRenderDeploymentStandaloneHasNoGroupEnv(t *testing.T) {
 	}
 }
 
+func TestRenderDeploymentCRIHostsDir(t *testing.T) {
+	t.Parallel()
+
+	const customHostsDir = "/etc/cri/conf.d/hosts"
+
+	for _, tt := range []struct {
+		name           string
+		criHostsDir    string
+		clusterCRIKind string
+		pullThrough    string
+		wantHostPath   string
+		wantMountPaths []string
+	}{
+		{
+			name:           "always mounts custom directory at both paths",
+			criHostsDir:    customHostsDir,
+			pullThrough:    clabernetesconstants.ImagePullThroughModeAlways,
+			wantHostPath:   customHostsDir,
+			wantMountPaths: []string{customHostsDir, clabernetesconstants.ContainerdCertsDir},
+		},
+		{
+			name:           "auto mounts custom directory at both paths",
+			criHostsDir:    customHostsDir,
+			pullThrough:    clabernetesconstants.ImagePullThroughModeAuto,
+			wantHostPath:   customHostsDir,
+			wantMountPaths: []string{customHostsDir, clabernetesconstants.ContainerdCertsDir},
+		},
+		{
+			name:        "never skips configured directory",
+			criHostsDir: customHostsDir,
+			pullThrough: clabernetesconstants.ImagePullThroughModeNever,
+		},
+		{
+			name:        "unset directory is skipped",
+			pullThrough: clabernetesconstants.ImagePullThroughModeAlways,
+		},
+		{
+			name:           "default directory is mounted once",
+			criHostsDir:    clabernetesconstants.ContainerdCertsDir,
+			pullThrough:    clabernetesconstants.ImagePullThroughModeAlways,
+			wantHostPath:   clabernetesconstants.ContainerdCertsDir,
+			wantMountPaths: []string{clabernetesconstants.ContainerdCertsDir},
+		},
+		{
+			name:        "root-equivalent directory is rejected",
+			criHostsDir: "//",
+			pullThrough: clabernetesconstants.ImagePullThroughModeAlways,
+		},
+		{
+			name:        "relative directory is rejected defensively",
+			criHostsDir: "etc/cri/hosts",
+			pullThrough: clabernetesconstants.ImagePullThroughModeAlways,
+		},
+		{
+			name:           "non-containerd cri skips configured directory",
+			criHostsDir:    customHostsDir,
+			clusterCRIKind: clabernetesconstants.KubernetesCRICrio,
+			pullThrough:    clabernetesconstants.ImagePullThroughModeAuto,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			node := &clabernetesapisv1alpha1.Node{}
+			node.Name = "node"
+			node.Namespace = "clabernetes"
+			node.Spec.Image = "registry.example/image:latest"
+
+			clusterCRIKind := tt.clusterCRIKind
+			if clusterCRIKind == "" {
+				clusterCRIKind = clabernetesconstants.KubernetesCRIContainerd
+			}
+
+			configManager := clabernetesconfig.NewFakeManager(
+				clabernetesconfig.WithCRIHostsDir(tt.criHostsDir),
+			)
+			reconciler := clabernetescontrollersnode.NewDeploymentReconciler(
+				&claberneteslogging.FakeInstance{},
+				"clabernetes",
+				"clabernetes",
+				clusterCRIKind,
+				func() clabernetesconfig.Manager {
+					return configManager
+				},
+			)
+
+			deployment := reconciler.Render(
+				&clabernetescontrollersnode.RenderInput{
+					Node: node,
+					Profile: testResolvedProfile(
+						t,
+						func(profile *clabernetescontrollersnode.ResolvedProfile) {
+							profile.PullThroughOverride = tt.pullThrough
+						},
+					),
+					GroupMembers: []string{"node"},
+				},
+			)
+
+			assertCRIHostsDir(
+				t,
+				deployment.Spec.Template.Spec.Volumes,
+				deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+				tt.wantHostPath,
+				tt.wantMountPaths,
+			)
+		})
+	}
+}
+
+func TestRenderDeploymentCRIKindOverride(t *testing.T) {
+	t.Parallel()
+
+	const customHostsDir = "/etc/cri/conf.d/hosts"
+
+	node := &clabernetesapisv1alpha1.Node{}
+	node.Name = "node"
+	node.Namespace = "clabernetes"
+	node.Spec.Image = "registry.example/image:latest"
+
+	configManager := clabernetesconfig.NewFakeManager(
+		clabernetesconfig.WithCRIHostsDir(customHostsDir),
+		clabernetesconfig.WithCRIKindOverride(
+			clabernetesconstants.KubernetesCRIContainerd,
+		),
+	)
+	reconciler := clabernetescontrollersnode.NewDeploymentReconciler(
+		&claberneteslogging.FakeInstance{},
+		"clabernetes",
+		"clabernetes",
+		clabernetesconstants.KubernetesCRIUnknown,
+		func() clabernetesconfig.Manager {
+			return configManager
+		},
+	)
+
+	deployment := reconciler.Render(
+		&clabernetescontrollersnode.RenderInput{
+			Node: node,
+			Profile: testResolvedProfile(
+				t,
+				func(profile *clabernetescontrollersnode.ResolvedProfile) {
+					profile.PullThroughOverride = clabernetesconstants.ImagePullThroughModeAuto
+				},
+			),
+			GroupMembers: []string{"node"},
+		},
+	)
+
+	if findVolumeByName(deployment.Spec.Template.Spec.Volumes, "cri-sock") == nil {
+		t.Fatal("expected containerd override to render the default CRI socket")
+	}
+
+	assertCRIHostsDir(
+		t,
+		deployment.Spec.Template.Spec.Volumes,
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+		customHostsDir,
+		[]string{customHostsDir, clabernetesconstants.ContainerdCertsDir},
+	)
+
+	criKindEnv := findEnv(
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		clabernetesconstants.LauncherCRIKindEnv,
+	)
+	if criKindEnv == nil || criKindEnv.Value != clabernetesconstants.KubernetesCRIContainerd {
+		t.Fatalf("expected effective containerd CRI env, got %+v", criKindEnv)
+	}
+}
+
+func assertCRIHostsDir(
+	t *testing.T,
+	volumes []k8scorev1.Volume,
+	volumeMounts []k8scorev1.VolumeMount,
+	wantHostPath string,
+	wantMountPaths []string,
+) {
+	t.Helper()
+
+	hostsVolume := findVolumeByName(volumes, "cri-hosts")
+	hostsMounts := filterVolumeMountsByName(volumeMounts, "cri-hosts")
+
+	if wantHostPath == "" {
+		if hostsVolume != nil {
+			t.Fatalf("expected no CRI hosts volume, got %+v", hostsVolume)
+		}
+
+		if len(hostsMounts) != 0 {
+			t.Fatalf("expected no CRI hosts mounts, got %+v", hostsMounts)
+		}
+
+		return
+	}
+
+	if hostsVolume == nil || hostsVolume.HostPath == nil ||
+		hostsVolume.HostPath.Path != wantHostPath {
+		t.Fatalf("unexpected CRI hosts volume: %+v", hostsVolume)
+	}
+
+	if hostsVolume.HostPath.Type == nil ||
+		*hostsVolume.HostPath.Type != k8scorev1.HostPathDirectory {
+		t.Fatalf("expected CRI hosts volume to require a directory: %+v", hostsVolume)
+	}
+
+	if len(hostsMounts) != len(wantMountPaths) {
+		t.Fatalf("expected %d CRI hosts mounts, got %+v", len(wantMountPaths), hostsMounts)
+	}
+
+	mountPaths := map[string]bool{}
+
+	for _, mount := range hostsMounts {
+		mountPaths[mount.MountPath] = mount.ReadOnly
+	}
+
+	for _, wantMountPath := range wantMountPaths {
+		if !mountPaths[wantMountPath] {
+			t.Fatalf("expected read-only mount at %q, got %v", wantMountPath, mountPaths)
+		}
+	}
+}
+
+func findVolumeByName(volumes []k8scorev1.Volume, name string) *k8scorev1.Volume {
+	for idx := range volumes {
+		if volumes[idx].Name == name {
+			return &volumes[idx]
+		}
+	}
+
+	return nil
+}
+
+func filterVolumeMountsByName(
+	volumeMounts []k8scorev1.VolumeMount,
+	name string,
+) []k8scorev1.VolumeMount {
+	filtered := []k8scorev1.VolumeMount{}
+
+	for _, mount := range volumeMounts {
+		if mount.Name == name {
+			filtered = append(filtered, mount)
+		}
+	}
+
+	return filtered
+}
+
 func TestRenderDeploymentGenericStatusProbes(t *testing.T) {
 	node := &clabernetesapisv1alpha1.Node{}
 	node.Name = "generic-node"

--- a/docs/guides/image-pull.md
+++ b/docs/guides/image-pull.md
@@ -249,6 +249,28 @@ Common paths:
 - K3s: `/run/k3s/containerd/containerd.sock`
 - Minikube: `/var/run/containerd/containerd.sock`
 
+### CRI Registry Hosts
+
+Some containerd installations keep registry mirror, TLS, and host configuration outside the
+default `/etc/containerd/certs.d` directory. Set `criHostsDir` to make that host directory
+available to all pull-through launchers:
+
+```yaml
+spec:
+  imagePull:
+    pullThroughOverride: always
+    criHostsDir: /path/to/containerd/hosts
+```
+
+The directory is mounted read-only at both its original path and `/etc/containerd/certs.d`.
+Keeping the original path available allows certificate paths rooted inside that directory tree
+to continue working, while the conventional path lets nerdctl use the same registry configuration
+as the node runtime. Absolute certificate paths outside `criHostsDir` are not mounted; keep those
+certificates under `criHostsDir` or make them available to the launcher separately. The configured
+path must be an existing directory on every containerd node that can run a pull-through launcher.
+It is not mounted when pull-through is disabled or the effective CRI kind is not containerd; a
+configured `criKindOverride` takes precedence over cluster auto-detection.
+
 ## Complete Examples
 
 ### Public Registry

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -763,6 +763,17 @@
                             "imagePull": {
                                 "description": "ImagePull holds configurations relevant to how clabernetes launcher pods handle pulling\nimages.",
                                 "properties": {
+                                    "criHostsDir": {
+                                        "description": "CRIHostsDir is an optional host directory containing containerd registry hosts\nconfiguration. When set and the effective CRI is containerd, the directory is mounted\nread-only into pull-through launchers both at its original path (so certificate paths rooted\nin this directory remain valid) and at containerd's conventional certs.d path used by\nnerdctl.",
+                                        "pattern": "^/.+",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                            {
+                                                "message": "criHostsDir must be an absolute non-root path without '.' or '..' segments",
+                                                "rule": "self.matches('^/.*[^/].*$') && !self.matches('(^|/)[.][.]?(/|$)')"
+                                            }
+                                        ]
+                                    },
                                     "criKindOverride": {
                                         "description": "CRIKindOverride allows for overriding the auto discovered cri flavor of the cluster -- this\nmay be useful if we fail to parse the cri kind for some reason, or in mixed cri flavor\nclusters -- however in the latter case, make sure that if you are using image pull through\nthat clabernetes workloads are only run on the nodes of the cri kind specified here!",
                                         "enum": [

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -642,6 +642,13 @@ func schema_clabernetes_clabernetes_apis_v1alpha1_ConfigImagePull(
 							Format:      "",
 						},
 					},
+					"criHostsDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CRIHostsDir is an optional host directory containing containerd registry hosts configuration. When set and the effective CRI is containerd, the directory is mounted read-only into pull-through launchers both at its original path (so certificate paths rooted in this directory remain valid) and at containerd's conventional certs.d path used by nerdctl.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"dockerDaemonConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DockerDaemonConfig allows for setting a default docker daemon config for launcher pods with the specified secret. The secret *must be present in the namespace of any given topology* -- so if you are configuring this at the \"global config\" level, ensure that you are deploying topologies into a specific namespace, or have ensured there is a secret of the given name in every namespace you wish to deploy a topology to. When set, insecure registries config option is ignored as it is assumed you are handling that in the given docker config. Note that the secret *must* contain a key \"daemon.json\" -- as this secret will be mounted to /etc/docker and docker will be expecting the config at /etc/docker/daemon.json.",

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/design.md
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/design.md
@@ -1,0 +1,79 @@
+## Context
+
+See `proposal.md` for motivation. Pull-through launchers call rootful nerdctl against the node's
+containerd socket, so nerdctl reads registry host namespaces from `/etc/containerd/certs.d` inside
+the launcher. Some Kubernetes distributions place the equivalent node-runtime directory elsewhere,
+and `hosts.toml` may contain absolute certificate paths rooted in that distribution-specific tree.
+
+Global Config already owns cluster-wide CRI socket/kind overrides and forms the base of every
+resolved launcher profile. Config changes enqueue Nodes for reconciliation, and Helm bootstraps the
+Config singleton through a ConfigMap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reuse one node directory without copying or rewriting registry configuration.
+- Preserve absolute certificate paths rooted in that directory.
+- Keep automatic pull-through fallback from depending on containerd-only host paths when the
+  effective CRI is not containerd.
+- Keep API, Helm, generated artifacts, runtime rendering, tests, and documentation aligned.
+
+**Non-Goals:**
+
+- Supporting CRI-O registry configuration or converting it to containerd hosts format.
+- Mounting certificate paths outside the configured directory.
+- Adding a per-Node or per-LauncherProfile node-filesystem path.
+- Creating a missing directory on Kubernetes nodes.
+
+## Decisions
+
+### 1. Keep the setting in global Config
+
+The directory describes node filesystem layout and must agree with scheduling and CRI selection, so
+it belongs beside the existing global CRI socket and kind overrides. A namespaced LauncherProfile
+override would imply workload owners can safely choose arbitrary node host paths, which is not a
+portable launcher policy.
+
+### 2. Mount one HostPath at two read-only destinations
+
+The source uses the Kubernetes `Directory` HostPath type so a typo fails explicitly rather than
+creating an empty directory. The same volume is mounted at its original absolute path for rooted
+certificate references and at `/etc/containerd/certs.d` for nerdctl discovery. The conventional
+path is emitted only once when it is also the source path.
+
+Copying files into an init-container volume was rejected because it would require extra privilege,
+startup work, update semantics, and certificate-path rewriting without improving the contract.
+
+### 3. Resolve one effective CRI kind for CRI-dependent rendering
+
+Deployment rendering selects the configured CRI kind override first and otherwise uses cluster
+detection. The socket mount, launcher environment, and registry-host mounts use that same effective
+kind. Registry-host mounts are omitted for non-containerd kinds and when pull-through is `never`.
+
+This keeps explicit mixed-cluster overrides functional and preserves `auto` fallback on clusters
+where containerd pull-through is unavailable.
+
+### 4. Validate the API and Helm path consistently
+
+The value must be an absolute, non-root path with no `.` or `..` segments. Rendering still cleans
+and defensively rejects an invalid path in case it receives data that predates validation. Helm
+quotes the ConfigMap scalar so spaces and comment characters remain part of the path.
+
+## Risks / Trade-offs
+
+- **The path must exist on every eligible node** → Use `Directory` HostPath and document the
+  scheduling constraint so failures are explicit.
+- **HostPath exposes node files to a privileged launcher** → Limit the mount to a configured
+  directory and mark every mount read-only; Config remains an administrator-owned global setting.
+- **External certificates may live elsewhere** → Do not broaden host access automatically;
+  document that those certificate paths need separate provisioning.
+- **A Config update rolls launcher Deployments** → This matches existing global launcher-default
+  reconciliation and is required for the new mount to take effect.
+
+## Migration Plan
+
+The field is optional and defaults to unset, so upgrades retain existing Deployments until an
+operator configures it. Generated CRDs/OpenAPI and the Helm schema are shipped with the controller
+change. Rollback consists of clearing the field, which reconciles the extra HostPath and mounts out
+of launcher Deployments.

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/proposal.md
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Pull-through launchers use nerdctl against the node's containerd socket, but they cannot currently
+reuse registry mirrors, TLS certificates, or host configuration stored outside nerdctl's default
+`/etc/containerd/certs.d` path. This causes image re-pulls to fail on distributions that keep the
+containerd hosts directory elsewhere even though the node runtime itself can pull the image.
+
+## What Changes
+
+- Add an optional global Config and Helm value for the node's containerd registry hosts directory.
+- For enabled pull-through on the effective containerd CRI, mount that host directory read-only at
+  its original absolute path and at `/etc/containerd/certs.d` inside launcher Pods.
+- Do not add the hostPath when pull-through is disabled or the effective CRI is not containerd, so
+  automatic pull-through fallback cannot prevent a launcher from starting.
+- Validate and document the path, preserve it through bootstrap merge/overwrite behavior, and cover
+  chart rendering and launcher Deployment rendering with focused tests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `launcher-profiles`: Define how global containerd registry-host configuration participates in
+  image pull-through and launcher Pod realization.
+- `documentation-site`: Require user guidance for configuring a non-default containerd hosts
+  directory and its path/certificate constraints.
+
+## Impact
+
+The change affects the Config API and generated CRD/OpenAPI artifacts, Config bootstrap and manager
+accessors, Helm values/schema/rendering, Node Deployment rendering and tests, and the image-pull
+guide. It adds no dependency and does not change existing behavior when the new setting is unset.

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/specs/documentation-site/spec.md
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/specs/documentation-site/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Custom containerd registry hosts configuration is documented
+
+The user documentation SHALL explain how to configure a non-default containerd registry hosts
+directory through the Config API, how the directory is mounted for pull-through launchers, and the
+node-path and certificate-path constraints that operators must satisfy.
+
+#### Scenario: Operator configures a custom hosts directory
+
+- **WHEN** an operator consults the image-pull guide for a containerd installation with a non-default hosts directory
+- **THEN** the guide provides the Config field, explains both read-only mount locations, and states that the directory must exist on every eligible containerd node
+
+#### Scenario: Hosts configuration references certificates
+
+- **WHEN** an operator uses certificate paths in containerd hosts configuration
+- **THEN** the guide explains that absolute certificate paths outside the configured directory are not mounted automatically

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/specs/launcher-profiles/spec.md
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/specs/launcher-profiles/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Global Config supplies containerd registry hosts to pull-through launchers
+
+Global Config SHALL accept an optional absolute, non-root containerd registry hosts directory that
+contains no `.` or `..` path segments. When pull-through is enabled and the effective CRI kind is
+containerd, the launcher Pod SHALL mount that node host directory read-only at both its original
+path and `/etc/containerd/certs.d`; when both paths are equal, it SHALL mount the directory only
+once. The effective CRI kind SHALL honor the configured CRI kind override before cluster
+auto-detection.
+
+#### Scenario: Custom containerd hosts directory is configured
+
+- **WHEN** pull-through is `auto` or `always`, the effective CRI is containerd, and Config declares a custom containerd hosts directory
+- **THEN** the launcher Pod requires that host directory and mounts it read-only at both the configured path and `/etc/containerd/certs.d`
+
+#### Scenario: Conventional containerd hosts directory is configured
+
+- **WHEN** Config declares `/etc/containerd/certs.d` for an enabled containerd pull-through launcher
+- **THEN** the launcher Pod mounts the directory read-only exactly once at `/etc/containerd/certs.d`
+
+#### Scenario: Pull-through is disabled
+
+- **WHEN** a launcher profile resolves pull-through mode to `never`
+- **THEN** the launcher Pod does not include the configured containerd hosts hostPath or mounts
+
+#### Scenario: Effective CRI is not containerd
+
+- **WHEN** pull-through mode is `auto` or `always` but neither the CRI override nor cluster detection selects containerd
+- **THEN** the launcher Pod does not include the configured containerd hosts hostPath or mounts

--- a/openspec/changes/archive/2026-08-13-cri-hosts-dir/tasks.md
+++ b/openspec/changes/archive/2026-08-13-cri-hosts-dir/tasks.md
@@ -1,0 +1,21 @@
+## 1. Config API and Bootstrap
+
+- [x] 1.1 Add the validated Config API field and regenerate CRD, OpenAPI, and client artifacts.
+- [x] 1.2 Expose the value through the Config manager and preserve Helm bootstrap merge and overwrite semantics with focused tests.
+- [x] 1.3 Add the quoted Helm value, JSON schema validation, and chart golden coverage.
+
+## 2. Launcher Deployment Rendering
+
+- [x] 2.1 Resolve one effective CRI kind from the override and cluster detection for CRI-dependent Deployment rendering.
+- [x] 2.2 Render the configured directory as a read-only HostPath at its original and conventional nerdctl paths only for enabled containerd pull-through.
+- [x] 2.3 Cover custom/default paths, disabled pull-through, invalid paths, non-containerd CRIs, and explicit containerd overrides.
+
+## 3. Documentation
+
+- [x] 3.1 Document Config usage, both mount locations, node path requirements, and certificate path limitations in the image-pull guide.
+
+## 4. Verification
+
+- [x] 4.1 Run focused and full non-e2e Go tests, chart rendering tests, formatting, lint, and whitespace checks.
+- [x] 4.2 Run generated-artifact verification and documentation validation.
+- [x] 4.3 Validate the OpenSpec change and confirm every changed file belongs to the feature.

--- a/openspec/specs/documentation-site/spec.md
+++ b/openspec/specs/documentation-site/spec.md
@@ -162,3 +162,19 @@ TCP/SSH checks apply to the primary Node.
 
 - **WHEN** a reader consults the Node or LauncherProfile documentation
 - **THEN** the documentation explains all-member readiness, Docker healthcheck requirements, process-level limitations, and primary-only TCP/SSH probes
+
+### Requirement: Custom containerd registry hosts configuration is documented
+
+The user documentation SHALL explain how to configure a non-default containerd registry hosts
+directory through the Config API, how the directory is mounted for pull-through launchers, and the
+node-path and certificate-path constraints that operators must satisfy.
+
+#### Scenario: Operator configures a custom hosts directory
+
+- **WHEN** an operator consults the image-pull guide for a containerd installation with a non-default hosts directory
+- **THEN** the guide provides the Config field, explains both read-only mount locations, and states that the directory must exist on every eligible containerd node
+
+#### Scenario: Hosts configuration references certificates
+
+- **WHEN** an operator uses certificate paths in containerd hosts configuration
+- **THEN** the guide explains that absolute certificate paths outside the configured directory are not mounted automatically

--- a/openspec/specs/launcher-profiles/spec.md
+++ b/openspec/specs/launcher-profiles/spec.md
@@ -138,3 +138,32 @@ The Node controller SHALL expose whether LauncherProfile resolution succeeded an
 
 - **WHEN** a LauncherProfile update is successfully applied to a Node
 - **THEN** Node status reports the new applied generation
+
+### Requirement: Global Config supplies containerd registry hosts to pull-through launchers
+
+Global Config SHALL accept an optional absolute, non-root containerd registry hosts directory that
+contains no `.` or `..` path segments. When pull-through is enabled and the effective CRI kind is
+containerd, the launcher Pod SHALL mount that node host directory read-only at both its original
+path and `/etc/containerd/certs.d`; when both paths are equal, it SHALL mount the directory only
+once. The effective CRI kind SHALL honor the configured CRI kind override before cluster
+auto-detection.
+
+#### Scenario: Custom containerd hosts directory is configured
+
+- **WHEN** pull-through is `auto` or `always`, the effective CRI is containerd, and Config declares a custom containerd hosts directory
+- **THEN** the launcher Pod requires that host directory and mounts it read-only at both the configured path and `/etc/containerd/certs.d`
+
+#### Scenario: Conventional containerd hosts directory is configured
+
+- **WHEN** Config declares `/etc/containerd/certs.d` for an enabled containerd pull-through launcher
+- **THEN** the launcher Pod mounts the directory read-only exactly once at `/etc/containerd/certs.d`
+
+#### Scenario: Pull-through is disabled
+
+- **WHEN** a launcher profile resolves pull-through mode to `never`
+- **THEN** the launcher Pod does not include the configured containerd hosts hostPath or mounts
+
+#### Scenario: Effective CRI is not containerd
+
+- **WHEN** pull-through mode is `auto` or `always` but neither the CRI override nor cluster detection selects containerd
+- **THEN** the launcher Pod does not include the configured containerd hosts hostPath or mounts


### PR DESCRIPTION
## Summary

- add a validated `criHostsDir` global Config field and Helm value
- mount custom containerd registry hosts read-only at both the configured path and `/etc/containerd/certs.d` for pull-through launchers
- use the effective CRI kind consistently, including `criKindOverride`, and skip containerd-only mounts for other runtimes
- add bootstrap, chart, deployment, generated schema, documentation, and OpenSpec coverage

## Why

Pull-through launchers use nerdctl against the node containerd socket. On distributions that store `hosts.toml`, mirrors, or TLS certificates outside `/etc/containerd/certs.d`, launcher-side image pulls could not reuse the node runtime configuration.

## Validation

- `make lint`
- `GOTOOLCHAIN=go1.25.12 make test` (332 tests)
- `make verify-generated`
- `make check-docs`
- strict validation of the archived change and modified OpenSpec capabilities

Cluster end-to-end and race tests were not run. Exercising this behavior end to end requires a cluster with a custom containerd hosts directory.
