### PR TITLE
Omit Directory type on cri-hosts hostPath

### DIFF
--- a/controllers/node/deployment.go
+++ b/controllers/node/deployment.go
@@ -610,7 +610,7 @@ func (r *DeploymentReconciler) renderDeploymentCRIHostsVolumes(
 			VolumeSource: k8scorev1.VolumeSource{
 				HostPath: &k8scorev1.HostPathVolumeSource{
 					Path: criHostsDir,
-					Type: clabernetesutil.ToPointer(k8scorev1.HostPathDirectory),
+					Type: clabernetesutil.ToPointer(k8scorev1.HostPathType("")),
 				},
 			},
 		},

--- a/controllers/node/deployment_test.go
+++ b/controllers/node/deployment_test.go
@@ -522,9 +522,8 @@ func assertCRIHostsDir(
 		t.Fatalf("unexpected CRI hosts volume: %+v", hostsVolume)
 	}
 
-	if hostsVolume.HostPath.Type == nil ||
-		*hostsVolume.HostPath.Type != k8scorev1.HostPathDirectory {
-		t.Fatalf("expected CRI hosts volume to require a directory: %+v", hostsVolume)
+	if hostsVolume.HostPath.Type == nil || *hostsVolume.HostPath.Type != "" {
+		t.Fatalf("expected CRI hosts volume to omit hostPath type: %+v", hostsVolume)
 	}
 
 	if len(hostsMounts) != len(wantMountPaths) {


### PR DESCRIPTION
Launcher pods on Talos fail to mount `cri-hosts` because kubelet type-checks `hostPath` `Directory` in its own mount namespace, where `/etc/cri/conf.d/hosts` does not exist. The node path is a directory; containerd bind-mounts it from the host. Render `cri-hosts` as an untyped hostPath, matching cri-sock, so pull-through still uses criHostsDir without that kubelet check.