### PR TITLE
fix: grouped direct Node runtime identities and port ownership

### DIFF
--- a/controllers/node/direct.go
+++ b/controllers/node/direct.go
@@ -733,6 +733,11 @@ func compileDirectExposedPorts(
 		}
 	}
 	portsByNode := map[string]map[string]clabernetesapisv1alpha1.NodeExposedPort{}
+	// portOwners tracks which member holds each Pod destination port. Group members share one
+	// Pod network namespace, so a port can only belong to one member: explicitly declared ports
+	// take precedence over image-derived ones, image-derived duplicates follow first-member-wins
+	// exactly like containerlab's first-come allocation on a shared namespace.
+	portOwners := map[string]string{}
 	for _, container := range plan.Containers {
 		if nodesByID[container.NodeID] == nil {
 			return nil, planInputError(
@@ -750,6 +755,20 @@ func compileDirectExposedPorts(
 			if profile.DisableAutoExpose && !explicit[container.NodeID][key] {
 				continue
 			}
+			if owner, taken := portOwners[key]; taken && owner != container.NodeID {
+				if explicit[container.NodeID][key] && explicit[owner][key] {
+					return nil, planInputError(
+						clabernetesinternaldeviceplan.ErrorUnsupported,
+						"services.ports",
+						"grouped direct Nodes expose the same Pod destination port",
+					)
+				}
+				if !explicit[container.NodeID][key] {
+					continue
+				}
+				delete(portsByNode[owner], key)
+			}
+			portOwners[key] = container.NodeID
 			portsByNode[container.NodeID][key] = clabernetesapisv1alpha1.NodeExposedPort{
 				DestinationPort: planned.Number,
 				ExposePort:      planned.Number,

--- a/controllers/node/direct_test.go
+++ b/controllers/node/direct_test.go
@@ -1855,8 +1855,12 @@ func TestCompileDirectExposedPortsKeepsAutoExposeParity(t *testing.T) {
 }
 
 func TestCompileDirectExposedPortsRejectsGroupedNamespaceCollision(t *testing.T) {
+	// Both members explicitly claim the same Pod destination port: that is contradictory user
+	// intent on one shared network namespace and must fail closed.
 	first := planInputTestNode("future-a", "uid-future-a", "opaque-package-kind", "example/a:1")
+	first.Spec.Ports = []string{"22/tcp"}
 	second := planInputTestNode("future-b", "uid-future-b", "another-package-kind", "example/b:1")
+	second.Spec.Ports = []string{"22/tcp"}
 	plan := clabernetesinternaldeviceplan.Plan{
 		Containers: []clabernetesinternaldeviceplan.ContainerPlan{
 			{
@@ -1885,6 +1889,88 @@ func TestCompileDirectExposedPortsRejectsGroupedNamespaceCollision(t *testing.T)
 		planningErr.Code != clabernetesinternaldeviceplan.ErrorUnsupported ||
 		planningErr.Field != "services.ports" {
 		t.Fatalf("compileDirectExposedPorts() error = %#v, want grouped collision", err)
+	}
+}
+
+func TestCompileDirectExposedPortsGroupedImagePortsFirstMemberWins(t *testing.T) {
+	// Image-derived (implicit) duplicate ports across group members are not user intent: the
+	// first member claims the port and later members skip it, matching containerlab's
+	// first-come allocation on a shared network namespace.
+	first := planInputTestNode("future-a", "uid-future-a", "opaque-package-kind", "example/a:1")
+	second := planInputTestNode("future-b", "uid-future-b", "another-package-kind", "example/b:1")
+	plan := clabernetesinternaldeviceplan.Plan{
+		Containers: []clabernetesinternaldeviceplan.ContainerPlan{
+			{
+				ID:     "container-a",
+				NodeID: string(first.GetUID()),
+				Ports:  []clabernetesinternaldeviceplan.Port{{Number: 80, Protocol: "TCP"}},
+			},
+			{
+				ID:     "container-b",
+				NodeID: string(second.GetUID()),
+				Ports:  []clabernetesinternaldeviceplan.Port{{Number: 80, Protocol: "TCP"}},
+			},
+		},
+	}
+
+	result, err := compileDirectExposedPorts(
+		plan,
+		&ResolvedProfile{DisableAutoExpose: true},
+		[]string{first.GetName(), second.GetName()},
+		map[string]*clabernetesapisv1alpha1.Node{
+			first.GetName(): first, second.GetName(): second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("compileDirectExposedPorts() error = %v, want first member to claim the port", err)
+	}
+
+	if result[second.GetName()] != nil {
+		t.Fatalf("second member ports = %+v, want none", result[second.GetName()])
+	}
+}
+
+func TestCompileDirectExposedPortsExplicitPortDisplacesImplicitOwner(t *testing.T) {
+	// An explicit declaration outranks another member's image-derived claim on the same port.
+	first := planInputTestNode("future-a", "uid-future-a", "opaque-package-kind", "example/a:1")
+	second := planInputTestNode("future-b", "uid-future-b", "another-package-kind", "example/b:1")
+	second.Spec.Ports = []string{"80/tcp"}
+	plan := clabernetesinternaldeviceplan.Plan{
+		Containers: []clabernetesinternaldeviceplan.ContainerPlan{
+			{
+				ID:     "container-a",
+				NodeID: string(first.GetUID()),
+				Ports:  []clabernetesinternaldeviceplan.Port{{Number: 80, Protocol: "TCP"}},
+			},
+			{
+				ID:     "container-b",
+				NodeID: string(second.GetUID()),
+				Ports:  []clabernetesinternaldeviceplan.Port{{Number: 80, Protocol: "TCP"}},
+			},
+		},
+	}
+
+	result, err := compileDirectExposedPorts(
+		plan,
+		&ResolvedProfile{DisableAutoExpose: true},
+		[]string{first.GetName(), second.GetName()},
+		map[string]*clabernetesapisv1alpha1.Node{
+			first.GetName(): first, second.GetName(): second,
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"compileDirectExposedPorts() error = %v, want explicit member to claim the port",
+			err,
+		)
+	}
+
+	if result[first.GetName()] != nil {
+		t.Fatalf("implicit member ports = %+v, want displaced", result[first.GetName()])
+	}
+
+	if result[second.GetName()] == nil || len(result[second.GetName()].Ports) != 1 {
+		t.Fatalf("explicit member ports = %+v, want port 80", result[second.GetName()])
 	}
 }
 

--- a/internal/directpod/renderer.go
+++ b/internal/directpod/renderer.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"path"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -662,6 +663,7 @@ func Render(plan clabernetesinternaldeviceplan.Plan,
 					Hostname:           options.Name,
 					DNSPolicy:          dns.policy,
 					DNSConfig:          dns.config,
+					HostAliases:        renderHostAliases(normalized, options.Name),
 					InitContainers:     initContainers,
 					Containers:         containers,
 					Volumes:            volumes,
@@ -669,6 +671,86 @@ func Render(plan clabernetesinternaldeviceplan.Plan,
 			},
 		},
 	}, nil
+}
+
+// renderHostAliases resolves the imported runtime identities that Docker DNS would resolve in
+// local containerlab: chassis component runtime names (e.g. "sros-a") and grouped logical Node
+// names other than the Pod hostname map to their Node's management address. Imported package
+// hooks (save, post-deploy) dial devices by these names.
+func renderHostAliases(
+	plan clabernetesinternaldeviceplan.Plan,
+	workloadName string,
+) []k8scorev1.HostAlias {
+	addressByNode := make(map[string]string, len(plan.Management))
+	for _, management := range plan.Management {
+		address := bareManagementAddress(management.IPv4)
+		if address == "" {
+			address = bareManagementAddress(management.IPv6)
+		}
+
+		if address == "" {
+			continue
+		}
+
+		addressByNode[management.NodeID] = address
+	}
+
+	hostnamesByAddress := map[string][]string{}
+	seen := map[string]bool{workloadName: true}
+	addHost := func(name, nodeID string) {
+		if name == "" || seen[name] {
+			return
+		}
+
+		address, resolved := addressByNode[nodeID]
+		if !resolved {
+			return
+		}
+
+		seen[name] = true
+		hostnamesByAddress[address] = append(hostnamesByAddress[address], name)
+	}
+
+	for _, node := range plan.Nodes {
+		addHost(node.Name, node.ID)
+	}
+
+	for _, container := range plan.Containers {
+		addHost(container.RuntimeID, container.NodeID)
+	}
+
+	if len(hostnamesByAddress) == 0 {
+		return nil
+	}
+
+	addresses := make([]string, 0, len(hostnamesByAddress))
+	for address := range hostnamesByAddress {
+		addresses = append(addresses, address)
+	}
+
+	sort.Strings(addresses)
+
+	aliases := make([]k8scorev1.HostAlias, 0, len(addresses))
+	for _, address := range addresses {
+		hostnames := hostnamesByAddress[address]
+		sort.Strings(hostnames)
+		aliases = append(aliases, k8scorev1.HostAlias{IP: address, Hostnames: hostnames})
+	}
+
+	return aliases
+}
+
+func bareManagementAddress(cidr string) string {
+	if cidr == "" {
+		return ""
+	}
+
+	address, _, found := strings.Cut(cidr, "/")
+	if !found {
+		return cidr
+	}
+
+	return address
 }
 
 func defaultApplicationContainer(


### PR DESCRIPTION
Two follow-up fixes for the direct runtime (#307), both hit when running grouped Nodes.

## Pod hostAliases for imported runtime identities

Grouped direct pods run chassis components and grouped logical nodes in one network namespace, but imported package hooks (save, post-deploy) dial devices by their runtime names — e.g. the SR OS save hook dials `sros-a` — which Docker DNS resolves in local containerlab but nothing resolves in-cluster, so the hook fails with `lookup sros-a: no such host`.

The pod renderer now maps chassis component runtime names and non-primary group node names to their Node's management address via `hostAliases`, mirroring what Docker DNS provides locally.

## Image-derived port collisions in grouped Nodes

Grouped Nodes sharing one pod frequently run the same image, so image-derived (EXPOSE) ports collided on the pod destination port and made every such group unplannable — two `network-multitool` nodes in one group could not deploy at all.

`compileDirectExposedPorts` now tracks port ownership:

- the first group member keeps an image-derived port, later image-derived duplicates are dropped
- an explicit topology port displaces an image-derived owner
- explicit-vs-explicit collisions remain a planning error

## Validation

- unit tests added for both ownership rules; the existing grouped-collision test now asserts the explicit-vs-explicit case
- verified on a cluster with a distributed SR-SIM (CPM-A + IOM) topology — save works via the component name — and with multi-member same-image linux groups deploying cleanly
