### PR TITLE
feat: report observedGeneration and serve Topology status as a subresource

### DIFF
--- a/apis/v1alpha1/topology.go
+++ b/apis/v1alpha1/topology.go
@@ -31,6 +31,7 @@ const (
 // topology file (ex: containerlab topology), and any associated configurations.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path="topologies"
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".status.kind",name=Kind,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.topologyState",name=State,type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
@@ -87,6 +88,12 @@ type TopologyStatus struct {
 	// Kind is the topology kind this CR represents -- "containerlab".
 	// +kubebuilder:validation:Enum=containerlab
 	Kind string `json:"kind"`
+	// ObservedGeneration is the metadata.generation of the Topology whose compiled child
+	// resources were most recently applied by the controller. Clients compare it against
+	// metadata.generation to know whether the reported readiness refers to the current
+	// definition.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// NodeCount is the number of (containerlab) nodes this Topology compiled to.
 	// +optional
 	NodeCount int `json:"nodeCount,omitempty"`

--- a/assets/crd/c9s.run_topologies.yaml
+++ b/assets/crd/c9s.run_topologies.yaml
@@ -1573,6 +1573,14 @@ spec:
                 description: NodeCount is the number of (containerlab) nodes this
                   Topology compiled to.
                 type: integer
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the metadata.generation of the Topology whose compiled child
+                  resources were most recently applied by the controller. Clients compare it against
+                  metadata.generation to know whether the reported readiness refers to the current
+                  definition.
+                format: int64
+                type: integer
               readyNodeCount:
                 description: ReadyNodeCount is the number of nodes of this Topology
                   that currently report ready.
@@ -1599,4 +1607,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/charts/clabernetes/crds/c9s.run_topologies.yaml
+++ b/charts/clabernetes/crds/c9s.run_topologies.yaml
@@ -1573,6 +1573,14 @@ spec:
                 description: NodeCount is the number of (containerlab) nodes this
                   Topology compiled to.
                 type: integer
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the metadata.generation of the Topology whose compiled child
+                  resources were most recently applied by the controller. Clients compare it against
+                  metadata.generation to know whether the reported readiness refers to the current
+                  definition.
+                format: int64
+                type: integer
               readyNodeCount:
                 description: ReadyNodeCount is the number of nodes of this Topology
                   that currently report ready.
@@ -1599,4 +1607,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/controllers/topology/conflict_test.go
+++ b/controllers/topology/conflict_test.go
@@ -150,6 +150,7 @@ func TestReconcileChildConflictBlocksChildrenAndClearsAfterResolution(t *testing
 	client := ctrlruntimefake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(topology, foreignNode, foreignLink, foreignProfile).
+		WithStatusSubresource(&clabernetesapisv1alpha1.Topology{}).
 		Build()
 	reconciler := &Reconciler{
 		Log:                 &claberneteslogging.FakeInstance{},

--- a/controllers/topology/status.go
+++ b/controllers/topology/status.go
@@ -56,10 +56,11 @@ func (r *Reconciler) reconcileStatusWithError(
 	}
 
 	desiredStatus := clabernetesapisv1alpha1.TopologyStatus{
-		Kind:           compiled.Kind,
-		NodeCount:      len(compiled.Nodes),
-		ReadyNodeCount: readyNodeCount,
-		LinkCount:      len(compiled.Links),
+		Kind:               compiled.Kind,
+		ObservedGeneration: topology.GetGeneration(),
+		NodeCount:          len(compiled.Nodes),
+		ReadyNodeCount:     readyNodeCount,
+		LinkCount:          len(compiled.Links),
 		TopologyReady: topologyError == "" &&
 			len(compiled.Nodes) > 0 &&
 			readyNodeCount == len(compiled.Nodes),
@@ -131,7 +132,9 @@ func (r *Reconciler) updateTopologyStatus(
 
 		current.Status = *desiredStatus
 
-		updateErr := r.Client.Update(ctx, current)
+		// The Topology CRD serves status as a subresource, so this write can never touch the
+		// spec -- api-server defaulted spec fields stay exactly as stored.
+		updateErr := r.Client.Status().Update(ctx, current)
 		if updateErr == nil {
 			updated = current
 		}

--- a/controllers/topology/status_test.go
+++ b/controllers/topology/status_test.go
@@ -46,15 +46,30 @@ func (r *countingTopologyReader) Get(
 
 var errInjectedTopologyConflict = errors.New("injected conflict")
 
-func (c *topologyConflictOnceClient) Update(
+// Status intercepts the status subresource writer -- the reconciler writes Topology status
+// exclusively through it.
+func (c *topologyConflictOnceClient) Status() ctrlruntimeclient.SubResourceWriter {
+	return &topologyConflictOnceStatusWriter{
+		SubResourceWriter: c.Client.Status(),
+		parent:            c,
+	}
+}
+
+type topologyConflictOnceStatusWriter struct {
+	ctrlruntimeclient.SubResourceWriter
+
+	parent *topologyConflictOnceClient
+}
+
+func (w *topologyConflictOnceStatusWriter) Update(
 	ctx context.Context,
 	obj ctrlruntimeclient.Object,
-	opts ...ctrlruntimeclient.UpdateOption,
+	opts ...ctrlruntimeclient.SubResourceUpdateOption,
 ) error {
-	c.updateCalls++
-	if c.updateCalls == 1 {
-		if c.beforeConflict != nil {
-			err := c.beforeConflict(ctx, obj)
+	w.parent.updateCalls++
+	if w.parent.updateCalls == 1 {
+		if w.parent.beforeConflict != nil {
+			err := w.parent.beforeConflict(ctx, obj)
 			if err != nil {
 				return err
 			}
@@ -67,7 +82,7 @@ func (c *topologyConflictOnceClient) Update(
 		)
 	}
 
-	return c.Client.Update(ctx, obj, opts...)
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
 }
 
 func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
@@ -86,6 +101,7 @@ func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
 	baseClient := ctrlruntimefake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(topology).
+		WithStatusSubresource(&clabernetesapisv1alpha1.Topology{}).
 		Build()
 	client := &topologyConflictOnceClient{
 		Client: baseClient,
@@ -99,7 +115,7 @@ func TestUpdateTopologyStatusRetriesResourceVersionConflict(t *testing.T) {
 
 			current.Status.TopologyState = clabernetesapisv1alpha1.TopologyStateDegraded
 
-			return baseClient.Update(ctx, current)
+			return baseClient.Status().Update(ctx, current)
 		},
 	}
 	apiReader := &countingTopologyReader{Reader: baseClient}
@@ -186,6 +202,7 @@ func TestReconcileStatusRemainsBounded(t *testing.T) {
 	client := ctrlruntimefake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objects...).
+		WithStatusSubresource(&clabernetesapisv1alpha1.Topology{}).
 		Build()
 	reconciler := &Reconciler{
 		Log:    &claberneteslogging.FakeInstance{},

--- a/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
+++ b/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
@@ -22,20 +22,7 @@ spec:
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
           - endpoints: ["srl1:e1-3", "host:eth13"]
-  deployment:
-    persistence:
-      enabled: false
-    scheduling: {}
-  expose:
-    disableAutoExpose: false
-    disableExpose: false
-    exposeType: LoadBalancer
-  imagePull: {}
   naming: prefixed
-  statusProbes:
-    enabled: false
-    probeConfiguration:
-      startupSeconds: 0
 status:
   kind: containerlab
   linkCount: 2

--- a/e2e/topology/basic/test-fixtures/golden/10-nodeprofile.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/10-nodeprofile.topology-basic.yaml
@@ -18,7 +18,6 @@ spec:
   expose:
     disableAutoExpose: false
     disableExpose: false
-    exposeType: LoadBalancer
     useNodeMgmtIpv4Address: false
     useNodeMgmtIpv6Address: false
   statusProbes:

--- a/e2e/topology/basic/test-fixtures/golden/10-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/10-topology.topology-basic.yaml
@@ -16,20 +16,7 @@ spec:
             image: ghcr.io/nokia/srlinux
             labels:
               c9s.run/exposePorts: "9273/tcp"
-  deployment:
-    persistence:
-      enabled: false
-    scheduling: {}
-  expose:
-    disableAutoExpose: false
-    disableExpose: false
-    exposeType: LoadBalancer
-  imagePull: {}
   naming: global
-  statusProbes:
-    enabled: false
-    probeConfiguration:
-      startupSeconds: 0
 status:
   kind: containerlab
   nodeCount: 1

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -22,20 +22,7 @@ spec:
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
           - endpoints: ["srl1:e1-3", "host:eth13"]
-  deployment:
-    persistence:
-      enabled: false
-    scheduling: {}
-  expose:
-    disableAutoExpose: false
-    disableExpose: false
-    exposeType: LoadBalancer
-  imagePull: {}
   naming: global
-  statusProbes:
-    enabled: false
-    probeConfiguration:
-      startupSeconds: 0
 status:
   kind: containerlab
   linkCount: 2

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -4140,6 +4140,11 @@
                                 "description": "NodeCount is the number of (containerlab) nodes this Topology compiled to.",
                                 "type": "integer"
                             },
+                            "observedGeneration": {
+                                "description": "ObservedGeneration is the metadata.generation of the Topology whose compiled child\nresources were most recently applied by the controller. Clients compare it against\nmetadata.generation to know whether the reported readiness refers to the current\ndefinition.",
+                                "format": "int64",
+                                "type": "integer"
+                            },
                             "readyNodeCount": {
                                 "description": "ReadyNodeCount is the number of nodes of this Topology that currently report ready.",
                                 "type": "integer"

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -3833,6 +3833,13 @@ func schema_clabernetes_clabernetes_apis_v1alpha1_TopologyStatus(
 							Format:      "",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the metadata.generation of the Topology whose compiled child resources were most recently applied by the controller. Clients compare it against metadata.generation to know whether the reported readiness refers to the current definition.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"nodeCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeCount is the number of (containerlab) nodes this Topology compiled to.",


### PR DESCRIPTION
## What

- Add `observedGeneration` to `TopologyStatus`, set from `metadata.generation` once the controller has applied the compiled child resources for the current spec.
- Serve the Topology CRD's status as a subresource and write it via `Status().Update`.
- Regenerate CRDs/openapi and the affected e2e golden fixtures.

## Why

The Topology CRD had no status subresource, so the controller's status writes were typed full-object updates. Those serialize the whole spec, which pinned api-server-defaulted fields to their Go zero values on the stored object — most visibly `statusProbes.enabled` flipping to `false` on any Topology created without an explicit `statusProbes` block, silently disabling readiness probing for the lab. With the subresource, status writes cannot touch spec, and stored Topology specs stay exactly what the client applied. The e2e golden fixtures had the clobbered spec baked in (materialized zero-value `deployment`/`expose`/`imagePull`/`statusProbes` blocks) and are regenerated accordingly.

`observedGeneration` gives clients — for example the containerlab clabernetes runtime — the standard convergence signal: the reported readiness refers to the current definition only once `status.observedGeneration == metadata.generation`. Without it, a client re-deploying a changed definition cannot distinguish "ready on the old spec" from "ready on the new one".

## Testing

- `controllers/topology` unit tests: fake clients now register the Topology status subresource; the conflict-retry test injects its conflict on the status writer.
- `e2e/clabverter` and `e2e/topology/basic` pass against a live cluster; goldens regenerated with `-update`.
- Exercised end to end with the containerlab clabernetes runtime on a real cluster: fresh deploy, reconcile with a definition change (deploy now waits until the new generation is observed and the change is rendered), and SR-SIM integrated and distributed labs.