### PR TITLE
Public lab compatibility for the direct runtime

### DIFF
--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -13,6 +13,7 @@ import (
 
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
 	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
+	claberneteserrors "github.com/clabernetes/clabernetes/errors"
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 	clabernetesutil "github.com/clabernetes/clabernetes/util"
 	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
@@ -385,6 +386,29 @@ func (c *Clabverter) load() error {
 
 	for _, unknownField := range unknownFields {
 		c.logger.Warn(unknownField)
+	}
+
+	// The lab name names the Topology object and its namespace, so it has to be a name Kubernetes
+	// can carry. The definition itself is emitted unchanged -- the compiler does not read the lab
+	// name out of it.
+	if sanitizedName := clabernetesutilkubernetes.SanitizeName(
+		c.clabConfig.Name,
+	); sanitizedName != c.clabConfig.Name {
+		if sanitizedName == "" {
+			return fmt.Errorf(
+				"%w: lab name %q holds no character a Kubernetes object name can be built from",
+				claberneteserrors.ErrParse,
+				c.clabConfig.Name,
+			)
+		}
+
+		c.logger.Warnf(
+			"lab name %q cannot name Kubernetes objects, using %q",
+			c.clabConfig.Name,
+			sanitizedName,
+		)
+
+		c.clabConfig.Name = sanitizedName
 	}
 
 	// set the destination namespace to the c9s-<topology name>

--- a/clabverter/files.go
+++ b/clabverter/files.go
@@ -190,7 +190,10 @@ func (c *Clabverter) handleStartupConfigs() error {
 			return err
 		}
 
-		configMapName := fmt.Sprintf("%s-%s-startup-config", c.clabConfig.Name, nodeName)
+		// The node name is the definition's, which Kubernetes may not be able to carry.
+		configMapName := clabernetesutilkubernetes.SanitizeName(
+			fmt.Sprintf("%s-%s-startup-config", c.clabConfig.Name, nodeName),
+		)
 
 		var rendered bytes.Buffer
 
@@ -549,7 +552,9 @@ func (c *Clabverter) handleExtraFiles() error {
 			return err
 		}
 
-		configMapName := fmt.Sprintf("%s-%s-files", c.clabConfig.Name, nodeName)
+		configMapName := clabernetesutilkubernetes.SanitizeName(
+			fmt.Sprintf("%s-%s-files", c.clabConfig.Name, nodeName),
+		)
 
 		templateVars := extraFilesConfigMapTemplateVars{
 			Name:       configMapName,

--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -154,6 +154,20 @@ type CompiledTopology struct {
 	Links []CompiledLink
 	// Mgmt holds the containerlab management network settings (if any).
 	Mgmt *clabernetesutilcontainerlab.MgmtNet
+	// NodeNameSources maps the name of every node that had to be renamed for Kubernetes back to
+	// the name the definition uses. Node-keyed policy on the Topology (files, resources, probes)
+	// is written against the definition's names, so the renderers translate through this.
+	NodeNameSources map[string]string
+}
+
+// SourceNodeName returns the name the definition uses for a compiled node. It is the compiled name
+// itself for every node Kubernetes could carry as written.
+func (t *CompiledTopology) SourceNodeName(nodeName string) string {
+	if sourceName, renamed := t.NodeNameSources[nodeName]; renamed {
+		return sourceName
+	}
+
+	return nodeName
 }
 
 // CompileTopology parses and compiles the given Topology's definition.

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -794,6 +794,53 @@ topology:
 	}
 }
 
+func TestCompileTopologyRejectsBindsOnReservedContainerPaths(t *testing.T) {
+	t.Parallel()
+
+	_, err := compileDefinition(t, `
+name: reserved-bind
+topology:
+  nodes:
+    panel:
+      kind: linux
+      image: alpine
+      binds:
+        - /etc/hosts:/etc/hosts:ro
+    ok:
+      kind: linux
+      image: alpine
+      binds:
+        - configs/app.yml:/app.yml:ro
+`)
+	if err == nil {
+		t.Fatal("a bind on a kubelet-managed path must fail compilation")
+	}
+
+	unsupported := &clabernetescompiler.UnsupportedFeaturesError{}
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected UnsupportedFeaturesError, got %T: %s", err, err)
+	}
+
+	matched := false
+
+	for _, diagnostic := range unsupported.Diagnostics {
+		if diagnostic.Code != "reserved-bind-path" {
+			continue
+		}
+
+		matched = true
+
+		if !strings.Contains(diagnostic.Message, "/etc/hosts") ||
+			!strings.Contains(diagnostic.Message, "panel") {
+			t.Fatalf("diagnostic must name the node and path, got %q", diagnostic.Message)
+		}
+	}
+
+	if !matched {
+		t.Fatalf("expected reserved-bind-path diagnostic, got %+v", unsupported.Diagnostics)
+	}
+}
+
 func TestCompileTopologyDocumentsRejectedVocabulary(t *testing.T) {
 	t.Parallel()
 

--- a/compiler/compilecontainerlab.go
+++ b/compiler/compilecontainerlab.go
@@ -15,6 +15,7 @@ import (
 	claberneteserrors "github.com/clabernetes/clabernetes/errors"
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
+	clabernetesutilkubernetes "github.com/clabernetes/clabernetes/util/kubernetes"
 	clabtypes "github.com/srl-labs/containerlab/types"
 	"gopkg.in/yaml.v3"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -99,6 +100,10 @@ func compileContainerlabDefinition(
 
 		return nil, err
 	}
+
+	// Renaming last keeps every diagnostic above pointing at the node names the definition
+	// actually writes.
+	sanitizeCompiledNodeNames(logger, compiled, diagnostics)
 
 	for _, warning := range diagnostics.warnings() {
 		logger.Warnf("topology compile: %s", formatDiagnostic(warning))
@@ -217,7 +222,10 @@ func validateNodeNetworkModes(
 		primary := clabernetesutilcontainerlab.ParseNetworkModeContainer(networkMode)
 
 		path := fmt.Sprintf("topology.nodes.%s.network-mode", nodeName)
-		if primary == "" || len(k8svalidation.IsDNS1123Label(primary)) != 0 {
+		// The primary is a containerlab node name, and node names Kubernetes cannot carry are
+		// sanitized at the end of the compile -- so what has to hold here is that the value names
+		// a node at all, not that it is already a Kubernetes name.
+		if primary == "" || clabernetesutilkubernetes.SanitizeName(primary) == "" {
 			diagnostics.add(Diagnostic{
 				Code: "unsupported-network-mode",
 				Path: path,

--- a/compiler/compilecontainerlab.go
+++ b/compiler/compilecontainerlab.go
@@ -92,6 +92,7 @@ func compileContainerlabDefinition(
 
 	validateNodeNetworkModes(compiled.Nodes, diagnostics)
 	validateNodeVocabularyPolicies(compiled.Nodes, diagnostics)
+	validateNodeBinds(compiled.Nodes, diagnostics)
 	validateNodeAliases(compiled.Nodes, diagnostics)
 
 	compiled.Links, err = compileContainerlabLinks(containerlabConfig, diagnostics)
@@ -352,6 +353,50 @@ func validateNodeVocabularyPolicies(
 					node.LinkApplyMode,
 				),
 			})
+		}
+	}
+}
+
+// validateNodeBinds rejects binds that land on container paths the kubelet or the direct
+// runtime owns: such a bind either renders an invalid Deployment (the kubelet already mounts
+// the path in every container) or silently shadows Pod-managed content. Docker containerlab
+// can bind these paths because it owns the container filesystem; direct device Pods cannot.
+func validateNodeBinds(
+	nodes map[string]*clabernetesutilcontainerlab.NodeDefinition,
+	diagnostics *compileDiagnostics,
+) {
+	const (
+		bindMinParts = 2
+		bindMaxParts = 3
+	)
+
+	for _, nodeName := range sortedNodeNames(nodes) {
+		for index, bind := range nodes[nodeName].Binds {
+			parts := strings.SplitN(bind, ":", bindMaxParts)
+			if len(parts) < bindMinParts {
+				continue
+			}
+
+			for _, half := range parts[:2] {
+				reason, reserved := clabernetesutilkubernetes.ReservedContainerPathReason(half)
+				if !reserved {
+					continue
+				}
+
+				diagnostics.add(Diagnostic{
+					Code: "reserved-bind-path",
+					Path: fmt.Sprintf("topology.nodes.%s.binds[%d]", nodeName, index),
+					Message: fmt.Sprintf(
+						"node %q bind %q uses reserved container path %q: %s",
+						nodeName,
+						bind,
+						half,
+						reason,
+					),
+				})
+
+				break
+			}
 		}
 	}
 }

--- a/compiler/names.go
+++ b/compiler/names.go
@@ -1,0 +1,156 @@
+package compiler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
+	claberneteserrors "github.com/clabernetes/clabernetes/errors"
+	claberneteslogging "github.com/clabernetes/clabernetes/logging"
+	clabernetesutilcontainerlab "github.com/clabernetes/clabernetes/util/containerlab"
+	clabernetesutilkubernetes "github.com/clabernetes/clabernetes/util/kubernetes"
+)
+
+// sanitizeCompiledNodeNames renames the compiled nodes whose containerlab name Kubernetes cannot
+// carry, and points every reference to them at the new name. c9s names the Node, Deployment and
+// Service objects after the containerlab node, so a topology naming its routers R1..R5 -- the most
+// common convention in public labs -- would otherwise be rejected by the API server with nothing
+// but a reconcile loop to show for it.
+//
+// The source name of every renamed node is kept on the compiled topology so the renderers can
+// still find the node-keyed policy the Topology author wrote.
+func sanitizeCompiledNodeNames(
+	logger claberneteslogging.Instance,
+	compiled *CompiledTopology,
+	diagnostics *compileDiagnostics,
+) {
+	renames, err := nodeNameRenames(compiled.Nodes)
+	if err != nil {
+		diagnostics.add(Diagnostic{
+			Code:    "colliding-node-names",
+			Path:    "topology.nodes",
+			Message: err.Error(),
+		})
+
+		return
+	}
+
+	if len(renames) == 0 {
+		return
+	}
+
+	nodes := make(map[string]*clabernetesutilcontainerlab.NodeDefinition, len(compiled.Nodes))
+	sources := make(map[string]string, len(renames))
+
+	for nodeName, nodeDefinition := range compiled.Nodes {
+		compiledName, renamed := renames[nodeName]
+		if renamed {
+			sources[compiledName] = nodeName
+		} else {
+			compiledName = nodeName
+		}
+
+		nodes[compiledName] = nodeDefinition
+	}
+
+	compiled.Nodes = nodes
+	compiled.NodeNameSources = sources
+
+	for _, nodeDefinition := range compiled.Nodes {
+		renameNetworkModePrimary(nodeDefinition, renames)
+	}
+
+	for idx := range compiled.Links {
+		renameLinkEndpointNode(&compiled.Links[idx].EndpointA, renames)
+		renameLinkEndpointNode(&compiled.Links[idx].EndpointB, renames)
+	}
+
+	logger.Warnf(
+		"topology compile: node names Kubernetes cannot carry were sanitized: %s",
+		formatNodeNameRenames(renames),
+	)
+}
+
+// nodeNameRenames returns the compiled name of every node name that needs one, keyed by the name
+// the definition uses. Two node names that differ only in something Kubernetes cannot carry (R1
+// and r1) would collapse onto one object, so that is an error rather than a silent merge.
+func nodeNameRenames(
+	nodes map[string]*clabernetesutilcontainerlab.NodeDefinition,
+) (map[string]string, error) {
+	renames := map[string]string{}
+	origins := make(map[string]string, len(nodes))
+
+	for _, nodeName := range sortedNodeNames(nodes) {
+		sanitized := clabernetesutilkubernetes.SanitizeName(nodeName)
+		if sanitized == "" {
+			return nil, fmt.Errorf(
+				"%w: node name %q holds no character a Kubernetes object name can be built from",
+				claberneteserrors.ErrInvalidData,
+				nodeName,
+			)
+		}
+
+		if origin, taken := origins[sanitized]; taken {
+			return nil, fmt.Errorf(
+				"%w: node names %q and %q both map onto the Kubernetes name %q; rename one of them",
+				claberneteserrors.ErrInvalidData,
+				origin,
+				nodeName,
+				sanitized,
+			)
+		}
+
+		origins[sanitized] = nodeName
+
+		if sanitized != nodeName {
+			renames[nodeName] = sanitized
+		}
+	}
+
+	return renames, nil
+}
+
+func renameNetworkModePrimary(
+	nodeDefinition *clabernetesutilcontainerlab.NodeDefinition,
+	renames map[string]string,
+) {
+	if nodeDefinition == nil {
+		return
+	}
+
+	primary := clabernetesutilcontainerlab.ParseNetworkModeContainer(nodeDefinition.NetworkMode)
+
+	compiledName, renamed := renames[primary]
+	if !renamed {
+		return
+	}
+
+	nodeDefinition.NetworkMode = clabernetesutilcontainerlab.NetworkModeContainerPrefix +
+		compiledName
+}
+
+func renameLinkEndpointNode(
+	endpoint *clabernetesapisv1alpha1.LinkEndpointSpec,
+	renames map[string]string,
+) {
+	if compiledName, renamed := renames[endpoint.NodeName]; renamed {
+		endpoint.NodeName = compiledName
+	}
+}
+
+func formatNodeNameRenames(renames map[string]string) string {
+	sourceNames := make([]string, 0, len(renames))
+	for sourceName := range renames {
+		sourceNames = append(sourceNames, sourceName)
+	}
+
+	sort.Strings(sourceNames)
+
+	formatted := make([]string, 0, len(sourceNames))
+	for _, sourceName := range sourceNames {
+		formatted = append(formatted, fmt.Sprintf("%s -> %s", sourceName, renames[sourceName]))
+	}
+
+	return strings.Join(formatted, ", ")
+}

--- a/compiler/names_test.go
+++ b/compiler/names_test.go
@@ -1,0 +1,200 @@
+package compiler_test
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
+	clabernetescompiler "github.com/clabernetes/clabernetes/compiler"
+	clabernetesconfig "github.com/clabernetes/clabernetes/config"
+	claberneteslogging "github.com/clabernetes/clabernetes/logging"
+	k8scorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const uppercaseNamesDefinition = `
+name: name-test
+topology:
+  defaults:
+    kind: linux
+    image: alpine:3
+  nodes:
+    R1: {}
+    Client_2: {}
+    R1-console:
+      network-mode: container:R1
+  links:
+    - endpoints: ["R1:eth1", "Client_2:eth1"]
+    - endpoints: ["Client_2:eth2", "host:ens5"]
+`
+
+func TestCompileSanitizesNodeNamesKubernetesCannotCarry(t *testing.T) {
+	compiled, err := compileDefinition(t, uppercaseNamesDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodeNames := make([]string, 0, len(compiled.Nodes))
+	for nodeName := range compiled.Nodes {
+		nodeNames = append(nodeNames, nodeName)
+	}
+
+	slices.Sort(nodeNames)
+
+	if !reflect.DeepEqual(nodeNames, []string{"client-2", "r1", "r1-console"}) {
+		t.Fatalf("compiled node names = %v, want the sanitized names", nodeNames)
+	}
+
+	for compiledName, sourceName := range map[string]string{
+		"r1":         "R1",
+		"client-2":   "Client_2",
+		"r1-console": "R1-console",
+	} {
+		if got := compiled.SourceNodeName(compiledName); got != sourceName {
+			t.Fatalf("SourceNodeName(%q) = %q, want %q", compiledName, got, sourceName)
+		}
+	}
+
+	if got := compiled.Nodes["r1-console"].NetworkMode; got != "container:r1" {
+		t.Fatalf("r1-console network-mode = %q, want container:r1", got)
+	}
+
+	expectedLinks := []clabernetescompiler.CompiledLink{
+		{
+			EndpointA: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "r1",
+				InterfaceName: "eth1",
+			},
+			EndpointB: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "client-2",
+				InterfaceName: "eth1",
+			},
+		},
+		{
+			EndpointA: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "client-2",
+				InterfaceName: "eth2",
+			},
+			EndpointB: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "host",
+				InterfaceName: "ens5",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(compiled.Links, expectedLinks) {
+		t.Fatalf("compiled links = %+v, want %+v", compiled.Links, expectedLinks)
+	}
+}
+
+func TestCompileRejectsNodeNamesCollidingOnceSanitized(t *testing.T) {
+	_, err := compileDefinition(t, `
+name: colliding
+topology:
+  nodes:
+    R1:
+      kind: linux
+      image: alpine:3
+    r1:
+      kind: linux
+      image: alpine:3
+`)
+	if err == nil || !strings.Contains(err.Error(), "both map onto") {
+		t.Fatalf("compile error = %v, want a colliding node name error", err)
+	}
+}
+
+// TestRenderFollowsSanitizedNodeNames pins the translation of the node-keyed policy a Topology
+// author writes: it names the nodes the definition names, while the objects carry the sanitized
+// names.
+func TestRenderFollowsSanitizedNodeNames(t *testing.T) {
+	topology := &clabernetesapisv1alpha1.Topology{}
+	topology.Name = "name-test"
+	topology.Namespace = "clabernetes"
+	topology.Spec.Definition.Containerlab = uppercaseNamesDefinition
+	topology.Spec.Deployment.FilesFromConfigMap = map[string][]clabernetesapisv1alpha1.FileFromConfigMap{
+		"R1": {{
+			FilePath:      "startup.cfg",
+			ConfigMapName: "name-test-r1-startup-config",
+			ConfigMapPath: "startup-config",
+		}},
+	}
+	topology.Spec.Deployment.Resources = map[string]k8scorev1.ResourceRequirements{
+		"R1": {Requests: k8scorev1.ResourceList{"memory": resource.MustParse("512Mi")}},
+	}
+	topology.Spec.StatusProbes = clabernetesapisv1alpha1.StatusProbes{
+		Enabled:       true,
+		ExcludedNodes: []string{"Client_2"},
+		NodeProbeConfigurations: map[string]clabernetesapisv1alpha1.ProbeConfiguration{
+			"R1": {StartupSeconds: 60},
+		},
+	}
+
+	compiled, err := clabernetescompiler.CompileTopology(
+		&claberneteslogging.FakeInstance{},
+		topology,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes := clabernetescompiler.RenderNodes(topology, compiled, clabernetesconfig.GetFakeManager)
+
+	var rendered *clabernetesapisv1alpha1.Node
+
+	for _, node := range nodes {
+		if node.GetName() == "r1" {
+			rendered = node
+		}
+	}
+
+	if rendered == nil {
+		t.Fatal("no r1 node was rendered")
+	}
+
+	if len(rendered.Spec.FilesFromConfigMap) != 1 ||
+		rendered.Spec.FilesFromConfigMap[0].ConfigMapName != "name-test-r1-startup-config" {
+		t.Fatalf("r1 files = %+v, want the payload keyed by R1", rendered.Spec.FilesFromConfigMap)
+	}
+
+	if rendered.Spec.ProfileRef == nil || rendered.Spec.ProfileRef.Name != "name-test-r1" {
+		t.Fatalf("r1 profile ref = %+v, want the dedicated profile", rendered.Spec.ProfileRef)
+	}
+
+	assertSanitizedProfiles(t, clabernetescompiler.RenderNodeProfiles(
+		topology,
+		compiled,
+		clabernetesconfig.GetFakeManager,
+	))
+}
+
+// assertSanitizedProfiles checks the policy the profiles carry for the renamed nodes.
+func assertSanitizedProfiles(t *testing.T, profiles []*clabernetesapisv1alpha1.NodeProfile) {
+	t.Helper()
+
+	for _, profile := range profiles {
+		if profile.GetName() == "name-test-r1" {
+			if profile.Spec.Resources == nil ||
+				profile.Spec.Resources.Requests.Memory().String() != "512Mi" {
+				t.Fatalf("r1 profile resources = %+v, want the policy keyed by R1",
+					profile.Spec.Resources)
+			}
+		}
+
+		if profile.Spec.StatusProbes == nil {
+			t.Fatalf("profile %q has no status probes", profile.GetName())
+		}
+
+		if !slices.Contains(profile.Spec.StatusProbes.ExcludedNodes, "client-2") {
+			t.Fatalf("profile %q excluded nodes = %v, want the sanitized node name",
+				profile.GetName(), profile.Spec.StatusProbes.ExcludedNodes)
+		}
+
+		if _, ok := profile.Spec.StatusProbes.NodeProbeConfigurations["r1"]; !ok {
+			t.Fatalf("profile %q node probe configurations = %v, want them keyed by r1",
+				profile.GetName(), profile.Spec.StatusProbes.NodeProbeConfigurations)
+		}
+	}
+}

--- a/compiler/render.go
+++ b/compiler/render.go
@@ -78,8 +78,9 @@ func topologyOwnedObjectMetadata(
 }
 
 // RenderNodes renders the Node objects for the compiled topology, sorted by name. The emitted
-// node names are the containerlab node names verbatim -- the namespace is the topology
-// boundary.
+// node names are the containerlab node names, sanitized only where Kubernetes cannot carry them
+// -- the namespace is the topology boundary. Node-keyed policy on the Topology is written against
+// the definition's names, so it is looked up by the node's source name.
 func RenderNodes(
 	topology *clabernetesapisv1alpha1.Topology,
 	compiled *CompiledTopology,
@@ -88,19 +89,20 @@ func RenderNodes(
 	nodes := make([]*clabernetesapisv1alpha1.Node, 0, len(compiled.Nodes))
 
 	for nodeName, nodeDefinition := range compiled.Nodes {
-		profileName := nodeProfileNameForNode(topology, nodeName)
+		sourceName := compiled.SourceNodeName(nodeName)
+		profileName := nodeProfileNameForNode(topology, compiled, nodeName)
 		node := &clabernetesapisv1alpha1.Node{
 			ObjectMeta: topologyOwnedObjectMetadata(topology, nodeName, configManagerGetter),
 			Spec: clabernetesapisv1alpha1.NodeSpec{
 				NodeDefinition: *nodeDefinition.DeepCopy(),
 				ProfileRef:     &k8scorev1.LocalObjectReference{Name: profileName},
 				FilesFromConfigMap: slices.Clone(
-					topology.Spec.Deployment.FilesFromConfigMap[nodeName],
+					topology.Spec.Deployment.FilesFromConfigMap[sourceName],
 				),
 				FilesFromSecret: slices.Clone(
-					topology.Spec.Deployment.FilesFromSecret[nodeName],
+					topology.Spec.Deployment.FilesFromSecret[sourceName],
 				),
-				FilesFromURL: slices.Clone(topology.Spec.Deployment.FilesFromURL[nodeName]),
+				FilesFromURL: slices.Clone(topology.Spec.Deployment.FilesFromURL[sourceName]),
 			},
 		}
 
@@ -128,9 +130,10 @@ func RenderNodes(
 
 func nodeProfileNameForNode(
 	topology *clabernetesapisv1alpha1.Topology,
+	compiled *CompiledTopology,
 	nodeName string,
 ) string {
-	if hasDistinctProfilePolicy(topology, nodeName) {
+	if hasDistinctProfilePolicy(topology, compiled.SourceNodeName(nodeName)) {
 		return clabernetesutilkubernetes.SafeConcatNameKubernetes(topology.GetName(), nodeName)
 	}
 
@@ -198,7 +201,7 @@ func RenderNodeProfiles(
 	sharedProfileNeeded := false
 
 	for nodeName := range compiled.Nodes {
-		if !hasDistinctProfilePolicy(topology, nodeName) {
+		if !hasDistinctProfilePolicy(topology, compiled.SourceNodeName(nodeName)) {
 			sharedProfileNeeded = true
 
 			continue
@@ -293,7 +296,9 @@ func renderTopologyNodeProfile(
 		spec.Deployment = deployment
 	}
 
-	spec.StatusProbes = topology.Spec.StatusProbes.DeepCopy()
+	// Probe policy is matched against Node object names, so the node names the author wrote have
+	// to follow the rename the compiler made.
+	spec.StatusProbes = compiledStatusProbes(topology, compiled)
 
 	if compiled.Mgmt != nil {
 		spec.Mgmt = &clabernetesapisv1alpha1.ManagementPolicy{
@@ -334,7 +339,8 @@ func renderPerNodeNodeProfile(
 		configManagerGetter,
 	)
 
-	if nodeResources, ok := topology.Spec.Deployment.Resources[nodeName]; ok {
+	if nodeResources, ok := topology.Spec.Deployment.
+		Resources[compiled.SourceNodeName(nodeName)]; ok {
 		profile.Spec.Resources = nodeResources.DeepCopy()
 	}
 
@@ -360,4 +366,46 @@ func imagePullIsZero(imagePull *clabernetesapisv1alpha1.NodeProfileImagePull) bo
 
 func deploymentIsZero(deployment *clabernetesapisv1alpha1.NodeProfileDeployment) bool {
 	return deployment.Persistence == nil
+}
+
+// compiledStatusProbes copies the Topology's probe policy with every node name it holds mapped
+// onto the compiled node name the Node objects carry.
+func compiledStatusProbes(
+	topology *clabernetesapisv1alpha1.Topology,
+	compiled *CompiledTopology,
+) *clabernetesapisv1alpha1.StatusProbes {
+	statusProbes := topology.Spec.StatusProbes.DeepCopy()
+	if len(compiled.NodeNameSources) == 0 {
+		return statusProbes
+	}
+
+	compiledNames := make(map[string]string, len(compiled.NodeNameSources))
+	for compiledName, sourceName := range compiled.NodeNameSources {
+		compiledNames[sourceName] = compiledName
+	}
+
+	for idx, nodeName := range statusProbes.ExcludedNodes {
+		if compiledName, renamed := compiledNames[nodeName]; renamed {
+			statusProbes.ExcludedNodes[idx] = compiledName
+		}
+	}
+
+	if len(statusProbes.NodeProbeConfigurations) != 0 {
+		nodeProbeConfigurations := make(
+			map[string]clabernetesapisv1alpha1.ProbeConfiguration,
+			len(statusProbes.NodeProbeConfigurations),
+		)
+
+		for nodeName, probeConfiguration := range statusProbes.NodeProbeConfigurations {
+			if compiledName, renamed := compiledNames[nodeName]; renamed {
+				nodeName = compiledName
+			}
+
+			nodeProbeConfigurations[nodeName] = probeConfiguration
+		}
+
+		statusProbes.NodeProbeConfigurations = nodeProbeConfigurations
+	}
+
+	return statusProbes
 }

--- a/controllers/node/direct.go
+++ b/controllers/node/direct.go
@@ -1522,7 +1522,9 @@ func (r *Reconciler) reconcileDirectDeployment(
 	err := r.Client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(rendered), existing)
 	if apimachineryerrors.IsNotFound(err) {
 		if err = r.Client.Create(ctx, rendered); err != nil {
-			return nil, fmt.Errorf("creating direct device Deployment: %w", err)
+			return nil, &deploymentApplyError{
+				operation: "creating direct device Deployment", cause: err,
+			}
 		}
 
 		return rendered, nil
@@ -1541,10 +1543,27 @@ func (r *Reconciler) reconcileDirectDeployment(
 	}
 	rendered.SetResourceVersion(existing.GetResourceVersion())
 	if err = r.Client.Update(ctx, rendered); err != nil {
-		return nil, fmt.Errorf("updating direct device Deployment: %w", err)
+		return nil, &deploymentApplyError{
+			operation: "updating direct device Deployment", cause: err,
+		}
 	}
 
 	return rendered, nil
+}
+
+// deploymentApplyError marks a failure to apply the rendered device Deployment to the cluster,
+// so the reconciler can surface it on the Node status instead of only in the manager log.
+type deploymentApplyError struct {
+	operation string
+	cause     error
+}
+
+func (e *deploymentApplyError) Error() string {
+	return e.operation + ": " + e.cause.Error()
+}
+
+func (e *deploymentApplyError) Unwrap() error {
+	return e.cause
 }
 
 func directDeploymentConforms(existing, rendered *k8sappsv1.Deployment) bool {

--- a/controllers/node/direct.go
+++ b/controllers/node/direct.go
@@ -1259,9 +1259,11 @@ func appendDirectPayload(
 	seen map[string]bool,
 	payload clabernetesinternaldeviceplan.PayloadInput,
 ) error {
-	signature := strings.Join([]string{
-		string(payload.Kind), payload.Reference, payload.Digest, fmt.Sprintf("%o", payload.Mode),
-	}, "\x00")
+	// Declarations landing on one destination conflict only when their content or mode
+	// differs. Grouped nodes legitimately declare the same file — a shared license is staged
+	// once per member ConfigMap, so the references differ while the bytes are identical — and
+	// identical bytes cannot conflict.
+	signature := payload.Digest + "\x00" + fmt.Sprintf("%o", payload.Mode)
 	if existing, exists := destinations[payload.Destination]; exists && existing != signature {
 		return planInputError(
 			clabernetesinternaldeviceplan.ErrorInvalidInput,

--- a/controllers/node/direct.go
+++ b/controllers/node/direct.go
@@ -165,6 +165,13 @@ func (r *Reconciler) reconcileDirect(
 	if err != nil {
 		return err
 	}
+	if err = r.reconcileDirectPeerDirectory(
+		ctx,
+		node.GetNamespace(),
+		compileNamespaceManagementIdentities(nodesByName, profile.Mgmt),
+	); err != nil {
+		return err
+	}
 	baseRequest := PlanInputCompileRequest{
 		Primary: node, GroupMembers: groupMembers, NodesByName: nodesByName,
 		Links: links.Items, Compatibility: compatibility, Payloads: payloads,

--- a/controllers/node/direct_test.go
+++ b/controllers/node/direct_test.go
@@ -2231,3 +2231,67 @@ func reconcileDirectTestDeployment(
 
 	return nil
 }
+
+func TestAppendDirectPayloadToleratesContentIdenticalGroupDeclarations(t *testing.T) {
+	t.Parallel()
+
+	digest := clabernetesinternaldeviceplan.Digest([]byte("license-content"))
+	result := []clabernetesinternaldeviceplan.PayloadInput{}
+	destinations := map[string]string{}
+	seen := map[string]bool{}
+	license := "/opt/nokia/sros/license.key"
+
+	// Two grouped nodes stage the same license into their own ConfigMaps: the references
+	// differ, the bytes do not. Both declarations must survive so each member's container
+	// receives its mount.
+	for _, payload := range []clabernetesinternaldeviceplan.PayloadInput{
+		{
+			ID: "payload-a", NodeID: "uid-ce5",
+			Kind:      clabernetesinternaldeviceplan.PayloadConfigMap,
+			Reference: "ns/anysec-ce5-files:key", Digest: digest,
+			Destination: license, Mode: 0o444,
+		},
+		{
+			ID: "payload-b", NodeID: "uid-ce5-iom",
+			Kind:      clabernetesinternaldeviceplan.PayloadConfigMap,
+			Reference: "ns/anysec-ce5-iom-files:key", Digest: digest,
+			Destination: license, Mode: 0o444,
+		},
+	} {
+		if err := appendDirectPayload(&result, destinations, seen, payload); err != nil {
+			t.Fatalf("content-identical group declarations must not conflict: %v", err)
+		}
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("payloads = %#v, want both group members", result)
+	}
+
+	// The same node re-declaring identical content collapses into the entry it already has.
+	if err := appendDirectPayload(&result, destinations, seen,
+		clabernetesinternaldeviceplan.PayloadInput{
+			ID: "payload-c", NodeID: "uid-ce5",
+			Kind:      clabernetesinternaldeviceplan.PayloadConfigMap,
+			Reference: "ns/other:key", Digest: digest,
+			Destination: license, Mode: 0o444,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("payloads = %#v, want same-node duplicate collapsed", result)
+	}
+
+	// Different bytes on the same destination stay a conflict.
+	err := appendDirectPayload(&result, destinations, seen,
+		clabernetesinternaldeviceplan.PayloadInput{
+			ID: "payload-d", NodeID: "uid-ce5-iom",
+			Kind:        clabernetesinternaldeviceplan.PayloadConfigMap,
+			Reference:   "ns/anysec-ce5-iom-files:other",
+			Digest:      clabernetesinternaldeviceplan.Digest([]byte("different")),
+			Destination: license, Mode: 0o444,
+		})
+	if err == nil || !strings.Contains(err.Error(), license) {
+		t.Fatalf("content conflict error = %v", err)
+	}
+}

--- a/controllers/node/directmanagement.go
+++ b/controllers/node/directmanagement.go
@@ -12,6 +12,7 @@ import (
 
 	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
 	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
+	clabernetesinternaldirectruntime "github.com/clabernetes/clabernetes/internal/directruntime"
 )
 
 type directManagementPool struct {
@@ -160,6 +161,129 @@ func allocateDirectManagementAddresses(
 	}
 
 	return result, nil
+}
+
+// compileNamespaceManagementIdentities derives every namespace node's management addresses —
+// the same explicit-or-allocated values compileDirectManagement realizes for its own group —
+// into the peer directory device Pods realize into /etc/hosts at runtime. Allocation is a
+// deterministic function of the namespace node set, so every reconcile derives the same
+// directory. Best effort by design: a peer whose declaration cannot be normalized is skipped
+// here and surfaces on that peer's own reconcile instead.
+func compileNamespaceManagementIdentities(
+	nodesByName map[string]*clabernetesapisv1alpha1.Node,
+	mgmt *clabernetesapisv1alpha1.ManagementPolicy,
+) []clabernetesinternaldirectruntime.PeerIdentity {
+	settings := clabernetesapisv1alpha1.ManagementPolicy{}
+	if mgmt != nil {
+		settings = *mgmt
+	}
+
+	if err := applyDefaultManagementPolicy(&settings); err != nil {
+		return nil
+	}
+
+	ipv4Pool, err := newDirectManagementPool(settings.IPv4Subnet, settings.IPv4Range, true)
+	if err != nil {
+		return nil
+	}
+
+	ipv6Pool, err := newDirectManagementPool(settings.IPv6Subnet, settings.IPv6Range, false)
+	if err != nil {
+		return nil
+	}
+
+	ipv4Allocations, err := allocateDirectManagementAddresses(
+		nodesByName,
+		ipv4Pool,
+		func(node *clabernetesapisv1alpha1.Node) string { return node.Spec.MgmtIPv4 },
+		settings.IPv4Gw,
+	)
+	if err != nil {
+		ipv4Allocations = nil
+	}
+
+	ipv6Allocations, err := allocateDirectManagementAddresses(
+		nodesByName,
+		ipv6Pool,
+		func(node *clabernetesapisv1alpha1.Node) string { return node.Spec.MgmtIPv6 },
+		settings.IPv6Gw,
+	)
+	if err != nil {
+		ipv6Allocations = nil
+	}
+
+	result := []clabernetesinternaldirectruntime.PeerIdentity(nil)
+
+	for name, node := range nodesByName {
+		if node == nil || strings.HasPrefix(node.Spec.NetworkMode, "container:") {
+			// Container-network-mode members carry no management identity of their own; their
+			// names alias the namespace owner through the group plan.
+			continue
+		}
+
+		identity := clabernetesinternaldirectruntime.PeerIdentity{
+			Name:    name,
+			Aliases: slices.Clone(node.Spec.Aliases),
+		}
+
+		// Chassis component runtime names ("pe1-a", "pe1-1") resolve through Docker DNS in
+		// local containerlab, and automation stacks dial devices by them.
+		for _, component := range node.Spec.Components {
+			if component == nil || component.Slot == "" {
+				continue
+			}
+
+			identity.Aliases = append(
+				identity.Aliases,
+				name+"-"+strings.ToLower(component.Slot),
+			)
+		}
+
+		ipv4, normalizeErr := normalizeDirectManagementAddress(node.Spec.MgmtIPv4, ipv4Pool)
+		if normalizeErr == nil {
+			if ipv4 == "" {
+				ipv4 = ipv4Allocations[name]
+			}
+
+			identity.IPv4 = bareDirectManagementAddress(ipv4)
+		}
+
+		ipv6, normalizeErr := normalizeDirectManagementAddress(node.Spec.MgmtIPv6, ipv6Pool)
+		if normalizeErr == nil {
+			if ipv6 == "" {
+				ipv6 = ipv6Allocations[name]
+			}
+
+			identity.IPv6 = bareDirectManagementAddress(ipv6)
+		}
+
+		if identity.IPv4 == "" && identity.IPv6 == "" {
+			continue
+		}
+
+		result = append(result, identity)
+	}
+
+	slices.SortFunc(result, func(
+		left, right clabernetesinternaldirectruntime.PeerIdentity,
+	) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	return result
+}
+
+func bareDirectManagementAddress(cidr string) string {
+	if cidr == "" {
+		return ""
+	}
+
+	address, _, found := strings.Cut(cidr, "/")
+	if !found {
+		return cidr
+	}
+
+	return address
 }
 
 func validateUniqueExplicitManagementAddresses(

--- a/controllers/node/directpeerdirectory.go
+++ b/controllers/node/directpeerdirectory.go
@@ -1,0 +1,90 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
+	clabernetesinternaldirectruntime "github.com/clabernetes/clabernetes/internal/directruntime"
+	clabernetesutilkubernetes "github.com/clabernetes/clabernetes/util/kubernetes"
+	k8scorev1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+)
+
+// reconcileDirectPeerDirectory maintains the namespace-scoped peer directory ConfigMap every
+// device Pod mounts. Content changes reach running Pods through the kubelet's ConfigMap sync,
+// so lab membership changes propagate without touching any Deployment — which would recreate
+// its Pod. The directory is deterministic over the namespace node set, so concurrent
+// reconciles of different primaries converge on identical bytes.
+func (r *Reconciler) reconcileDirectPeerDirectory(
+	ctx context.Context,
+	namespace string,
+	peers []clabernetesinternaldirectruntime.PeerIdentity,
+) error {
+	content, err := clabernetesinternaldirectruntime.RenderPeerDirectory(peers)
+	if err != nil {
+		return fmt.Errorf("rendering peer directory: %w", err)
+	}
+
+	annotations, globalLabels := r.configManagerGetter().GetAllMetadata()
+	labels := map[string]string{
+		clabernetesconstants.LabelApp: clabernetesconstants.Clabernetes,
+	}
+
+	maps.Copy(labels, globalLabels)
+
+	rendered := &k8scorev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        clabernetesinternaldirectruntime.PeerDirectoryConfigMapName,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: map[string]string{
+			clabernetesinternaldirectruntime.PeerDirectoryConfigMapKey: string(content),
+		},
+	}
+
+	existing := &k8scorev1.ConfigMap{}
+
+	err = r.Client.Get(
+		ctx,
+		apimachinerytypes.NamespacedName{Namespace: namespace, Name: rendered.GetName()},
+		existing,
+	)
+	if apimachineryerrors.IsNotFound(err) {
+		if err = r.Client.Create(ctx, rendered); err != nil {
+			return fmt.Errorf("creating peer directory ConfigMap: %w", err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("reading peer directory ConfigMap: %w", err)
+	}
+
+	if existing.Data[clabernetesinternaldirectruntime.PeerDirectoryConfigMapKey] ==
+		rendered.Data[clabernetesinternaldirectruntime.PeerDirectoryConfigMapKey] &&
+		clabernetesutilkubernetes.ExistingMapStringStringContainsAllExpectedKeyValues(
+			existing.Labels, rendered.Labels,
+		) {
+		return nil
+	}
+
+	existing.Data = rendered.Data
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
+
+	maps.Copy(existing.Labels, rendered.Labels)
+
+	if err = r.Client.Update(ctx, existing); err != nil {
+		return fmt.Errorf("updating peer directory ConfigMap: %w", err)
+	}
+
+	return nil
+}

--- a/controllers/node/directpeerdirectory_test.go
+++ b/controllers/node/directpeerdirectory_test.go
@@ -1,0 +1,147 @@
+//nolint:testpackage // dense fixture-driven tests exercise one boundary end to end.
+package node
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
+	clabernetesconfig "github.com/clabernetes/clabernetes/config"
+	clabernetesinternaldirectruntime "github.com/clabernetes/clabernetes/internal/directruntime"
+	k8scorev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileDirectPeerDirectoryMaintainsNamespaceConfigMap(t *testing.T) {
+	t.Parallel()
+
+	scheme := nodeReconcileTestScheme(t)
+	client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &Reconciler{Client: client, configManagerGetter: func() clabernetesconfig.Manager {
+		return clabernetesconfig.NewFakeManager()
+	}}
+
+	peers := make([]clabernetesinternaldirectruntime.PeerIdentity, 0, 3)
+	peers = append(peers,
+		clabernetesinternaldirectruntime.PeerIdentity{Name: "gnmic", IPv4: "172.50.50.21"},
+		clabernetesinternaldirectruntime.PeerIdentity{
+			Name: "pe1", IPv4: "172.50.50.11", Aliases: []string{"pe1-a", "pe1-1"},
+		},
+	)
+
+	if err := reconciler.reconcileDirectPeerDirectory(
+		context.Background(),
+		"lab-a",
+		peers,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	stored := &k8scorev1.ConfigMap{}
+	if err := client.Get(context.Background(), apimachinerytypes.NamespacedName{
+		Namespace: "lab-a",
+		Name:      clabernetesinternaldirectruntime.PeerDirectoryConfigMapName,
+	}, stored); err != nil {
+		t.Fatal(err)
+	}
+
+	content := stored.Data[clabernetesinternaldirectruntime.PeerDirectoryConfigMapKey]
+	if !strings.Contains(content, "pe1-a") || !strings.Contains(content, "172.50.50.21") {
+		t.Fatalf("peer directory content = %q", content)
+	}
+
+	parsed, err := clabernetesinternaldirectruntime.ParsePeerDirectory([]byte(content))
+	if err != nil || len(parsed) != 2 {
+		t.Fatalf("stored directory parse = %#v, %v", parsed, err)
+	}
+
+	firstVersion := stored.GetResourceVersion()
+
+	// An unchanged directory must not churn the object.
+	if err = reconciler.reconcileDirectPeerDirectory(
+		context.Background(),
+		"lab-a",
+		peers,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = client.Get(context.Background(), apimachinerytypes.NamespacedName{
+		Namespace: "lab-a",
+		Name:      clabernetesinternaldirectruntime.PeerDirectoryConfigMapName,
+	}, stored); err != nil {
+		t.Fatal(err)
+	}
+
+	if stored.GetResourceVersion() != firstVersion {
+		t.Fatal("unchanged peer directory rewrote the ConfigMap")
+	}
+
+	// A membership change lands as an update.
+	if err = reconciler.reconcileDirectPeerDirectory(
+		context.Background(),
+		"lab-a",
+		append(peers, clabernetesinternaldirectruntime.PeerIdentity{
+			Name: "added", IPv4: "172.50.50.99",
+		}),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = client.Get(context.Background(), apimachinerytypes.NamespacedName{
+		Namespace: "lab-a",
+		Name:      clabernetesinternaldirectruntime.PeerDirectoryConfigMapName,
+	}, stored); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(
+		stored.Data[clabernetesinternaldirectruntime.PeerDirectoryConfigMapKey],
+		"added",
+	) {
+		t.Fatalf("membership change is absent: %q", stored.Data)
+	}
+}
+
+func TestCompileNamespaceManagementIdentitiesDerivesComponentAliases(t *testing.T) {
+	t.Parallel()
+
+	nodesByName := map[string]*clabernetesapisv1alpha1.Node{
+		"pe1": {
+			ObjectMeta: metav1.ObjectMeta{Name: "pe1", UID: "uid-pe1"},
+			Spec: clabernetesapisv1alpha1.NodeSpec{
+				NodeDefinition: clabernetesapisv1alpha1.NodeDefinition{
+					MgmtIPv4: "172.50.50.11",
+					Components: []*clabernetesapisv1alpha1.Component{
+						{Slot: "A"}, {Slot: "1"},
+					},
+				},
+			},
+		},
+		"pe1-console": {
+			ObjectMeta: metav1.ObjectMeta{Name: "pe1-console", UID: "uid-console"},
+			Spec: clabernetesapisv1alpha1.NodeSpec{
+				NodeDefinition: clabernetesapisv1alpha1.NodeDefinition{
+					NetworkMode: "container:pe1",
+				},
+			},
+		},
+	}
+
+	peers := compileNamespaceManagementIdentities(
+		nodesByName,
+		&clabernetesapisv1alpha1.ManagementPolicy{IPv4Subnet: "172.50.50.0/24"},
+	)
+
+	if len(peers) != 1 || peers[0].Name != "pe1" || peers[0].IPv4 != "172.50.50.11" {
+		t.Fatalf("namespace identities = %#v", peers)
+	}
+
+	if len(peers[0].Aliases) != 2 || peers[0].Aliases[0] != "pe1-a" ||
+		peers[0].Aliases[1] != "pe1-1" {
+		t.Fatalf("component aliases = %#v", peers[0].Aliases)
+	}
+}

--- a/controllers/node/directstatus.go
+++ b/controllers/node/directstatus.go
@@ -16,6 +16,7 @@ import (
 	clabernetesinternalocimetadata "github.com/clabernetes/clabernetes/internal/ocimetadata"
 	k8sappsv1 "k8s.io/api/apps/v1"
 	k8scorev1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachinerymeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,6 +66,18 @@ func directPreflightDiagnostic(err error) (reason, message string, report bool) 
 	var metadataErr *clabernetesinternalocimetadata.Error
 	if errors.As(err, &metadataErr) {
 		return "OCIMetadata" + string(metadataErr.Code), metadataErr.Error(), true
+	}
+
+	var applyErr *deploymentApplyError
+	if errors.As(err, &applyErr) {
+		// The API server rejecting the rendered Deployment is terminal until the spec changes;
+		// anything else (a timeout, a conflict) is retried and may clear on its own.
+		if apimachineryerrors.IsInvalid(applyErr.cause) ||
+			apimachineryerrors.IsBadRequest(applyErr.cause) {
+			return "DeploymentInvalid", applyErr.Error(), true
+		}
+
+		return "DeploymentApplyFailed", applyErr.Error(), true
 	}
 
 	return "", "", false

--- a/controllers/node/directstatus_test.go
+++ b/controllers/node/directstatus_test.go
@@ -15,13 +15,93 @@ import (
 	claberneteslogging "github.com/clabernetes/clabernetes/logging"
 	k8sappsv1 "k8s.io/api/apps/v1"
 	k8scorev1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachinerymeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	apimachineryfield "k8s.io/apimachinery/pkg/util/validation/field"
 	clientgoevents "k8s.io/client-go/tools/events"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestReportDirectPreflightFailureStampsDeploymentApplyErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cause      error
+		wantReason string
+	}{
+		{
+			name: "api server rejects the rendered deployment",
+			cause: apimachineryerrors.NewInvalid(
+				apimachineryschema.GroupKind{Group: "apps", Kind: "Deployment"},
+				"panel",
+				apimachineryfield.ErrorList{apimachineryfield.Invalid(
+					apimachineryfield.NewPath("spec", "template", "spec", "containers").
+						Index(0).Child("volumeMounts").Index(1).Child("mountPath"),
+					"/etc/hosts",
+					"must be unique",
+				)},
+			),
+			wantReason: "DeploymentInvalid",
+		},
+		{
+			name: "transient apply failure",
+			cause: apimachineryerrors.NewServerTimeout(
+				apimachineryschema.GroupResource{Group: "apps", Resource: "deployments"},
+				"create",
+				1,
+			),
+			wantReason: "DeploymentApplyFailed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := nodeReconcileTestScheme(t)
+			node := nodeReconcileTestNode()
+			client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&clabernetesapisv1alpha1.Node{}).WithObjects(node).Build()
+			reconciler := &Reconciler{Client: client, apiReader: client}
+
+			err := reconciler.reportDirectPreflightFailure(
+				context.Background(),
+				node,
+				&deploymentApplyError{
+					operation: "creating direct device Deployment",
+					cause:     test.cause,
+				},
+			)
+			if err != nil {
+				t.Fatalf("reportDirectPreflightFailure() error = %v", err)
+			}
+
+			stored := &clabernetesapisv1alpha1.Node{}
+			if err = client.Get(
+				context.Background(),
+				ctrlruntimeclient.ObjectKeyFromObject(node),
+				stored,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			condition := apimachinerymeta.FindStatusCondition(
+				stored.Status.Conditions,
+				clabernetesapisv1alpha1.NodeConditionPlanApplied,
+			)
+			if condition == nil || condition.Status != metav1.ConditionFalse ||
+				condition.Reason != test.wantReason ||
+				!strings.Contains(condition.Message, "creating direct device Deployment") {
+				t.Fatalf("PlanApplied condition = %#v, want reason %q", condition, test.wantReason)
+			}
+		})
+	}
+}
 
 func TestUpdateDirectStatusesUsesCurrentPlanPodAndKubernetesContainerState(t *testing.T) {
 	ctx := context.Background()

--- a/docs/concepts/containerlab-differences.md
+++ b/docs/concepts/containerlab-differences.md
@@ -47,8 +47,15 @@ diagnostic. Nothing is silently dropped.
 
 ## Naming and metadata
 
-- **Node names are Kubernetes object names.** They must be DNS-1123 labels, and the namespace
-  is the topology boundary.
+- **Node names are Kubernetes object names.** Kubernetes only takes lowercase DNS labels, so a
+  node name it cannot carry is sanitized: the name is lower-cased, every other character becomes
+  `-`, a name starting with a digit is prefixed with `clab-`, and a name longer than 63
+  characters is truncated and suffixed with a hash. `R1` becomes `r1`, `PE_1` becomes `pe-1`.
+  Every reference follows the node -- links, `network-mode: container:<node>`, and the node-keyed
+  policy on the Topology (`filesFromConfigMap`, `filesFromSecret`, `filesFromURL`, `resources`,
+  `statusProbes`) is still written with the name the definition uses. Two node names that differ
+  only in something Kubernetes cannot carry (`R1` and `r1`) would become one object, and that
+  fails compilation. The namespace is the topology boundary.
 - **`labels` become Kubernetes labels** on the emitted Node, its Deployment, and Pods
   (selectable with `kubectl`) instead of Docker container labels. Labels Kubernetes would
   reject, reserved `c9s.run/` keys, and controller-owned keys fail compilation.

--- a/docs/concepts/containerlab-differences.md
+++ b/docs/concepts/containerlab-differences.md
@@ -65,6 +65,10 @@ diagnostic. Nothing is silently dropped.
 - **Containers restart with their Pod.** `restart-policy` accepts `always` and
   `unless-stopped`; Docker's `no` and `on-failure` cannot exist in a shared Pod and are
   rejected at compile time.
+- **A failing `exec` command does not stop the node.** The topology's `exec` list runs as a
+  Kubernetes PostStart hook, and a failed hook would take the container down; a command that
+  fails is instead reported on the node's container log and the remaining commands still run,
+  which is what containerlab does. Commands a kind's own deployment records stay fail-closed.
 - **`stages` are rejected.** Multi-node boot orchestration gates the nodes of one lab against
   each other on a single host; direct device Pods start independently. `startup-delay` is
   honored per node.

--- a/docs/guides/mtu.md
+++ b/docs/guides/mtu.md
@@ -56,6 +56,27 @@ One floor applies: the wire never sizes fragments below 1200 bytes of payload, s
 network smaller than roughly 1250 bytes the outer datagrams fall back to ordinary IP
 fragmentation. Links still work there; the wire just stops adapting below that point.
 
+## The management network is different
+
+Everything above is about lab **links**. A node's **management** interface is not a wire: it is
+a leg of the per-namespace management mesh, which rides the Pod network encapsulated, so it
+carries the Pod network MTU minus that encapsulation (about 1430 bytes on a 1500-byte Pod
+network). Two things keep that from surprising a device:
+
+- **The size is reported to the device.** A kind that configures its management interface from
+  the runtime's management network (SR Linux sets `mgmt0.0 ip-mtu`) receives the size the mesh
+  actually carries instead of assuming 1500.
+- **Management TCP handshakes are clamped to it.** Some devices present a management port whose
+  size the application fixes and cannot lower (SR OS presents 1514). Their handshakes crossing
+  the mesh have the advertised maximum segment lowered to what the mesh carries, so both peers
+  send segments that fit. Without it these flows are a black hole: the connection completes and
+  then stalls on the first full-size segment -- a TLS certificate, a NETCONF hello -- because a
+  drop on a veth produces no fragmentation-needed to learn from. The clamp only ever lowers a
+  size, and only on the management mesh; lab links keep the MTU the topology asked for.
+
+Nothing here is configurable, and raising the Pod network MTU raises the management path with
+it.
+
 ## Links that never cross the Pod network
 
 Links with both endpoints in the same Pod, loopbacks, and host links are plain kernel

--- a/internal/deviceplan/managementmtu.go
+++ b/internal/deviceplan/managementmtu.go
@@ -1,0 +1,64 @@
+package deviceplan
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// sysfsInterfaceRoot is where the kernel publishes the attributes of the interfaces present in
+// the caller's network namespace.
+const sysfsInterfaceRoot = "/sys/class/net"
+
+// ManagementPathMTU reports the MTU of the management path c9s realized for one logical Node, as
+// the device sees it. The management mesh is bounded by the Pod underlay minus the encapsulation
+// it rides in, which is smaller than the 1500 bytes a device assumes by default -- an imported
+// package that configures its management interface from the runtime's management network then
+// configures the size that actually fits, instead of black-holing every packet above the path
+// MTU (there is no router on the path to answer with fragmentation-needed).
+//
+// The value is read from the realized interface rather than carried in the plan because the
+// bound depends on the CNI MTU of the Kubernetes node the Pod landed on, which the controller
+// does not know when it plans. A management path this process cannot observe reports 0, which
+// leaves the imported package on its own default.
+func ManagementPathMTU(plan Plan, nodeID string) int {
+	return interfaceMTU(managementInterfaceName(plan, nodeID))
+}
+
+// managementInterfaceName returns the name the device's management interface has in the Pod
+// network namespace.
+func managementInterfaceName(plan Plan, nodeID string) string {
+	for _, management := range plan.Management {
+		if management.NodeID != nodeID {
+			continue
+		}
+
+		if management.Interposition != nil && management.Interposition.DeviceInterface != "" {
+			return management.Interposition.DeviceInterface
+		}
+
+		return management.InterfaceName
+	}
+
+	return ""
+}
+
+func interfaceMTU(name string) int {
+	if name == "" || name != filepath.Base(name) || name == "." || name == ".." {
+		return 0
+	}
+
+	// The name is a single path element validated above, so the read stays inside sysfs.
+	raw, err := os.ReadFile(filepath.Join(sysfsInterfaceRoot, name, "mtu")) //nolint:gosec
+	if err != nil {
+		return 0
+	}
+
+	mtu, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || mtu <= 0 {
+		return 0
+	}
+
+	return mtu
+}

--- a/internal/deviceplan/mapper.go
+++ b/internal/deviceplan/mapper.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	clabernetesutilkubernetes "github.com/clabernetes/clabernetes/util/kubernetes"
 	"github.com/dustin/go-humanize"
 	"github.com/google/shlex"
 	clabtypes "github.com/srl-labs/containerlab/types"
@@ -178,7 +179,9 @@ func appendEvaluatedNode(
 	// than making its existence depend on kind-specific file generation.
 	ensureArtifactsVolume(plan, node.Input.ID)
 	artifactFileIDs := appendGeneratedArtifactPlans(plan, node)
-	appendPayloadPlans(plan, node, input.Payloads, primaryContainerID)
+	if err := appendPayloadPlans(plan, node, input.Payloads, primaryContainerID); err != nil {
+		return err
+	}
 	recordedActionCount, err := appendRecordedDeploymentActions(
 		plan,
 		node,
@@ -805,10 +808,23 @@ func appendPayloadPlans(
 	node *EvaluatedNode,
 	payloads []PayloadInput,
 	containerID string,
-) {
+) error {
 	for _, payload := range payloads {
 		if payload.NodeID != node.Input.ID {
 			continue
+		}
+		if reason, reserved := clabernetesutilkubernetes.ReservedContainerPathReason(
+			payload.Destination,
+		); reserved {
+			return nodeMappingError(
+				node.Input.ID,
+				"files",
+				fmt.Sprintf(
+					"file destination %q collides with a reserved container path: %s",
+					payload.Destination,
+					reason,
+				),
+			)
 		}
 		volumeID := ensureArtifactsVolume(plan, node.Input.ID)
 		fileID := "file/" + payload.ID
@@ -821,15 +837,17 @@ func appendPayloadPlans(
 			Destination: payload.Destination,
 			Mode:        payload.Mode, Sensitive: payload.Sensitive,
 		})
-		plan.Mounts = append(plan.Mounts, MountPlan{
-			ID:          mountID,
-			ContainerID: containerID,
-			VolumeID:    volumeID,
-			SourcePath:  "payloads/" + payload.ID,
-			Destination: payload.Destination,
-			ReadOnly:    true,
-		})
-		appendContainerMountID(plan, containerID, mountID)
+		if !planHasEquivalentMount(plan, containerID, volumeID, payload) {
+			plan.Mounts = append(plan.Mounts, MountPlan{
+				ID:          mountID,
+				ContainerID: containerID,
+				VolumeID:    volumeID,
+				SourcePath:  "payloads/" + payload.ID,
+				Destination: payload.Destination,
+				ReadOnly:    true,
+			})
+			appendContainerMountID(plan, containerID, mountID)
+		}
 		plan.Actions = append(plan.Actions, Action{
 			ID: "prepare/" + payload.ID, Phase: PhasePrepare,
 			Target: ActionTarget{NodeID: node.Input.ID},
@@ -837,6 +855,28 @@ func appendPayloadPlans(
 			File:   &FileAction{FileID: fileID},
 		})
 	}
+
+	return nil
+}
+
+// planHasEquivalentMount reports whether a user bind already realized this payload's content at
+// the payload's own destination in the same container (a bind whose source and target are the
+// same path). Rendering the payload projection again would produce an invalid Deployment with
+// a duplicate mountPath.
+func planHasEquivalentMount(
+	plan *Plan,
+	containerID string,
+	volumeID string,
+	payload PayloadInput,
+) bool {
+	for _, mount := range plan.Mounts {
+		if mount.ContainerID == containerID && mount.Destination == payload.Destination &&
+			mount.VolumeID == volumeID && mount.SourcePath == "payloads/"+payload.ID {
+			return true
+		}
+	}
+
+	return false
 }
 
 func appendStoragePlans(
@@ -966,6 +1006,17 @@ func appendUserBindPlan(
 		source = "/" + source
 	}
 	target := path.Clean(parts[1])
+	if reason, reserved := clabernetesutilkubernetes.ReservedContainerPathReason(target); reserved {
+		return nodeMappingError(
+			node.Input.ID,
+			"definition.binds",
+			fmt.Sprintf(
+				"user bind target %q collides with a reserved container path: %s",
+				target,
+				reason,
+			),
+		)
+	}
 	volumeID := ensureArtifactsVolume(plan, node.Input.ID)
 	matched := false
 	for _, payload := range payloads {

--- a/internal/deviceplan/mapper.go
+++ b/internal/deviceplan/mapper.go
@@ -1113,7 +1113,7 @@ func appendExecActions(
 				NamespaceOwnerID: containerNamespaceOwner(plan, containerID),
 			},
 			Kind: ActionExec,
-			Exec: &ExecAction{Command: command, Wait: true},
+			Exec: &ExecAction{Command: command, Wait: true, ContinueOnError: true},
 		})
 	}
 

--- a/internal/deviceplan/postdeploy.go
+++ b/internal/deviceplan/postdeploy.go
@@ -405,6 +405,9 @@ func (a Adapter) rehydrateImportedDeployment(
 			return nil, fmt.Errorf("constructing imported post-deploy Node: %w", constructErr)
 		}
 		managementNetwork := runtimeManagement(management)
+		// The device configures its management interface from the runtime's management network;
+		// tell it the size the mesh can actually carry.
+		managementNetwork.MTU = ManagementPathMTU(normalizedPlan, nodeInput.ID)
 		if initErr := runImportedRuntimeHook(
 			nodeInput.ID,
 			"postDeployment.initialization",

--- a/internal/deviceplan/types.go
+++ b/internal/deviceplan/types.go
@@ -453,10 +453,15 @@ type ActionTarget struct {
 
 // ExecAction executes an existing user- or kind-declared command without a shell by default.
 type ExecAction struct {
-	Command        []string `json:"command"`
-	Shell          bool     `json:"shell,omitempty"`
-	Wait           bool     `json:"wait"`
-	TimeoutSeconds int      `json:"timeoutSeconds,omitempty"`
+	Command []string `json:"command"`
+	Shell   bool     `json:"shell,omitempty"`
+	Wait    bool     `json:"wait"`
+	// ContinueOnError keeps the lifecycle phase running when the command fails. The topology's
+	// own exec list is best effort in containerlab -- a failing command is reported and the node
+	// keeps running -- and a PostStart hook that fails would instead take the whole container
+	// down. Commands a kind's own deployment recorded stay fail-closed.
+	ContinueOnError bool `json:"continueOnError,omitempty"`
+	TimeoutSeconds  int  `json:"timeoutSeconds,omitempty"`
 }
 
 // FileWriteMode describes how one staged artifact is applied to an existing container path.

--- a/internal/deviceplan/userbind_internal_test.go
+++ b/internal/deviceplan/userbind_internal_test.go
@@ -68,6 +68,70 @@ func TestAppendUserBindPlanMountsDirectoryPayloads(t *testing.T) {
 	}
 }
 
+func TestAppendUserBindPlanRejectsReservedTarget(t *testing.T) {
+	t.Parallel()
+
+	err := appendUserBindPlan(
+		&Plan{},
+		userBindTestNode(),
+		[]PayloadInput{{ID: "payload-1", NodeID: "node-a", Destination: "/etc/hosts"}},
+		"container-1",
+		0,
+		"/etc/hosts:/etc/hosts:ro",
+	)
+	if err == nil || !strings.Contains(err.Error(), "/etc/hosts") {
+		t.Fatalf("reserved bind target error = %v", err)
+	}
+}
+
+func TestAppendPayloadPlansRejectsReservedDestination(t *testing.T) {
+	t.Parallel()
+
+	err := appendPayloadPlans(
+		&Plan{},
+		userBindTestNode(),
+		[]PayloadInput{{ID: "payload-1", NodeID: "node-a", Destination: "/etc/hosts"}},
+		"container-1",
+	)
+	if err == nil || !strings.Contains(err.Error(), "/etc/hosts") {
+		t.Fatalf("reserved payload destination error = %v", err)
+	}
+}
+
+func TestAppendPayloadPlansSkipsMountAlreadyRealizedByUserBind(t *testing.T) {
+	t.Parallel()
+
+	plan := &Plan{}
+	payloads := []PayloadInput{
+		{ID: "payload-1", NodeID: "node-a", Destination: "/data/shared.txt"},
+	}
+
+	// A bind whose source and target are the same path ("/data/shared.txt:/data/shared.txt")
+	// plans the payload's content at the payload's own destination.
+	if err := appendUserBindPlan(
+		plan,
+		userBindTestNode(),
+		payloads,
+		"container-1",
+		0,
+		"/data/shared.txt:/data/shared.txt:ro",
+	); err != nil {
+		t.Fatalf("appendUserBindPlan() error = %v", err)
+	}
+
+	if err := appendPayloadPlans(plan, userBindTestNode(), payloads, "container-1"); err != nil {
+		t.Fatalf("appendPayloadPlans() error = %v", err)
+	}
+
+	if len(plan.Mounts) != 1 || plan.Mounts[0].Destination != "/data/shared.txt" {
+		t.Fatalf("same-path bind must plan exactly one mount, got %#v", plan.Mounts)
+	}
+
+	if len(plan.Files) != 1 {
+		t.Fatalf("payload file plan must survive the mount de-duplication, got %#v", plan.Files)
+	}
+}
+
 func TestAppendUserBindPlanFailsClosedWithoutPayloadBacking(t *testing.T) {
 	t.Parallel()
 

--- a/internal/directpod/renderer.go
+++ b/internal/directpod/renderer.go
@@ -47,6 +47,7 @@ const (
 	connectivityStateName            = "clabwire-state"
 	connectivityStatePath            = "/var/run/clabernetes/connectivity"
 	connectivityRevisionVolumeName   = "clabwire-revision"
+	peerDirectoryVolumeName          = "node-peer-directory"
 	connectivityRevisionMountPath    = "/var/run/clabernetes/connectivity-revision"
 	hostNetworkNamespaceName         = "worker-host-network-namespace"
 	hostNetworkNamespaceSourcePath   = "/proc/1/ns"
@@ -450,6 +451,22 @@ func Render(plan clabernetesinternaldeviceplan.Plan,
 		Name:         connectivityStateName,
 		VolumeSource: k8scorev1.VolumeSource{EmptyDir: &k8scorev1.EmptyDirVolumeSource{}},
 	})
+
+	// The peer directory is deliberately a namespace-scoped ConfigMap volume rather than
+	// rendered HostAliases: lab membership changes update the ConfigMap only, which the
+	// kubelet syncs into running Pods, so adding or removing a node never recreates Pods.
+	// Optional, so a Pod can start before the directory exists.
+	peerDirectoryOptional := true
+
+	volumes = append(volumes, k8scorev1.Volume{
+		Name: peerDirectoryVolumeName,
+		VolumeSource: k8scorev1.VolumeSource{ConfigMap: &k8scorev1.ConfigMapVolumeSource{
+			LocalObjectReference: k8scorev1.LocalObjectReference{
+				Name: clabernetesinternaldirectruntime.PeerDirectoryConfigMapName,
+			},
+			Optional: &peerDirectoryOptional,
+		}},
+	})
 	if options.ConnectivityRevisionConfigMapName != "" {
 		volumes = append(volumes, k8scorev1.Volume{
 			Name: connectivityRevisionVolumeName,
@@ -709,7 +726,9 @@ func Render(plan clabernetesinternaldeviceplan.Plan,
 // renderHostAliases resolves the imported runtime identities that Docker DNS would resolve in
 // local containerlab: chassis component runtime names (e.g. "sros-a") and grouped logical Node
 // names other than the Pod hostname map to their Node's management address. Imported package
-// hooks (save, post-deploy) dial devices by these names.
+// hooks (save, post-deploy) dial devices by these names. Namespace peers deliberately do not
+// ride HostAliases — they arrive through the peer-directory ConfigMap at runtime, so lab
+// membership changes never touch the Deployment spec (which would recreate the Pod).
 func renderHostAliases(
 	plan clabernetesinternaldeviceplan.Plan,
 	workloadName string,
@@ -1374,6 +1393,11 @@ func renderApplicationLifecycle(
 			{Name: lifecycleVolumeName, MountPath: lifecycleBinaryRoot, ReadOnly: true},
 			{Name: planVolumeName, MountPath: lifecyclePlanRoot, ReadOnly: true},
 			{Name: lifecycleScratchName, MountPath: lifecycleScratchRoot},
+			{
+				Name:      peerDirectoryVolumeName,
+				MountPath: clabernetesinternaldirectruntime.ApplicationPeerDirectoryRoot,
+				ReadOnly:  true,
+			},
 		}
 		if readinessTargets[containerID] || postStartTargets[containerID] ||
 			importedSaveTargets[containerID] {
@@ -2476,6 +2500,11 @@ func renderHelpers(
 		planMount,
 		inputMount,
 		stateMount,
+		{
+			Name:      peerDirectoryVolumeName,
+			MountPath: clabernetesinternaldirectruntime.ConnectivityPeerDirectoryRoot,
+			ReadOnly:  true,
+		},
 	}
 
 	if options.ConnectivityRevisionConfigMapName != "" {

--- a/internal/directpod/renderer.go
+++ b/internal/directpod/renderer.go
@@ -265,7 +265,40 @@ func validateNormalizedPlan(plan clabernetesinternaldeviceplan.Plan) error {
 		}
 	}
 
+	mountDestinations := map[string]string{}
+
+	for mountIndex, mount := range plan.Mounts {
+		key := mount.ContainerID + "\x00" + mount.Destination
+		if existing := mountDestinations[key]; existing != "" {
+			return &clabernetesinternaldeviceplan.Error{
+				Code:     clabernetesinternaldeviceplan.ErrorInvariant,
+				Field:    fmt.Sprintf("mounts[%d].destination", mountIndex),
+				NodeID:   containerNodeID(plan, mount.ContainerID),
+				Behavior: "kubernetes-workload-preflight",
+				Message: fmt.Sprintf(
+					"mounts %q and %q both land on container path %q; "+
+						"a Kubernetes container cannot mount one path twice",
+					existing,
+					mount.ID,
+					mount.Destination,
+				),
+			}
+		}
+
+		mountDestinations[key] = mount.ID
+	}
+
 	return nil
+}
+
+func containerNodeID(plan clabernetesinternaldeviceplan.Plan, containerID string) string {
+	for _, container := range plan.Containers {
+		if container.ID == containerID {
+			return container.NodeID
+		}
+	}
+
+	return ""
 }
 
 func directPlanPreflightError(nodeID, field, message string) error {

--- a/internal/directpod/renderer_test.go
+++ b/internal/directpod/renderer_test.go
@@ -197,6 +197,89 @@ func TestRenderGivesEveryApplicationContainerThePodAddress(t *testing.T) {
 	}
 }
 
+func TestRenderMountsPeerDirectoryIntoEveryDeviceContainer(t *testing.T) {
+	t.Parallel()
+
+	plan := renderablePlan()
+
+	deployment, err := clabernetesinternaldirectpod.Render(
+		plan,
+		clabernetesinternaldirectpod.Options{
+			Name: "device-a", Namespace: "lab-a", PlanConfigMapName: "device-a-plan-abc",
+			InputConfigMapName:                "device-a-plan-input-abc",
+			ConnectivityRevisionConfigMapName: "device-a-connectivity",
+			PreparationImage:                  "example/c9s@sha256:1111",
+			ConnectivityImage:                 "example/c9s@sha256:1111",
+			EnableContainerStopSignals:        true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod := deployment.Spec.Template.Spec
+
+	// Namespace peers must never ride the Deployment spec: a lab membership change would
+	// recreate the Pod. They arrive through the peer-directory ConfigMap at runtime instead.
+	volumeFound := false
+
+	for _, volume := range pod.Volumes {
+		if volume.Name != "node-peer-directory" {
+			continue
+		}
+
+		volumeFound = true
+
+		if volume.ConfigMap == nil ||
+			volume.ConfigMap.Name != clabernetesinternaldirectruntime.PeerDirectoryConfigMapName ||
+			volume.ConfigMap.Optional == nil || !*volume.ConfigMap.Optional {
+			t.Fatalf("peer directory volume = %#v", volume)
+		}
+	}
+
+	if !volumeFound {
+		t.Fatalf("peer directory volume is absent: %#v", pod.Volumes)
+	}
+
+	mountedAt := func(mounts []k8scorev1.VolumeMount, path string) bool {
+		for _, mount := range mounts {
+			if mount.Name == "node-peer-directory" && mount.MountPath == path && mount.ReadOnly {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, container := range pod.Containers {
+		if container.Name == clabernetesinternaldirectpod.ConnectivityContainerName {
+			continue
+		}
+
+		if !mountedAt(
+			container.VolumeMounts,
+			clabernetesinternaldirectruntime.ApplicationPeerDirectoryRoot,
+		) {
+			t.Fatalf("device container %q misses the peer directory: %#v",
+				container.Name, container.VolumeMounts)
+		}
+	}
+
+	for _, container := range pod.InitContainers {
+		if container.Name != clabernetesinternaldirectpod.ConnectivityContainerName {
+			continue
+		}
+
+		if !mountedAt(
+			container.VolumeMounts,
+			clabernetesinternaldirectruntime.ConnectivityPeerDirectoryRoot,
+		) {
+			t.Fatalf("connectivity sidecar misses the peer directory: %#v",
+				container.VolumeMounts)
+		}
+	}
+}
+
 func TestRenderCreatesDirectApplicationContainersFromGenericPlan(t *testing.T) {
 	t.Parallel()
 

--- a/internal/directpod/renderer_test.go
+++ b/internal/directpod/renderer_test.go
@@ -98,6 +98,32 @@ func TestValidatePlanRejectsUnportableHostDeviceAndSecurityInputs(t *testing.T) 
 	}
 }
 
+func TestValidatePlanRejectsDuplicateContainerMountDestinations(t *testing.T) {
+	t.Parallel()
+
+	plan := renderablePlan()
+	plan.Mounts = append(plan.Mounts,
+		clabernetesinternaldeviceplan.MountPlan{
+			ID: "mount/payload-hosts", ContainerID: "node-a/root",
+			VolumeID: "node-a/artifacts", SourcePath: "payloads/a", Destination: "/etc/hosts",
+		},
+		clabernetesinternaldeviceplan.MountPlan{
+			ID: "mount/bind-hosts", ContainerID: "node-a/root",
+			VolumeID: "node-a/artifacts", SourcePath: "payloads/a", Destination: "/etc/hosts",
+		},
+	)
+
+	err := clabernetesinternaldirectpod.ValidatePlan(plan)
+
+	var planningErr *clabernetesinternaldeviceplan.Error
+	if !errors.As(err, &planningErr) ||
+		planningErr.Code != clabernetesinternaldeviceplan.ErrorInvariant ||
+		planningErr.NodeID != "node-a" ||
+		!strings.Contains(planningErr.Message, "/etc/hosts") {
+		t.Fatalf("ValidatePlan() error = %#v", err)
+	}
+}
+
 func TestRenderAppliesProfilePullDefaultWithoutOverwritingExplicitNodePolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/directruntime/connectivity.go
+++ b/internal/directruntime/connectivity.go
@@ -1198,6 +1198,10 @@ func runConnectivity(
 		return err
 	}
 
+	// The owned hosts entries are asserted before readiness gates application containers, so
+	// the device process boots with its own identity and the namespace peers resolvable.
+	assertOwnedHosts(effectivePlan)
+
 	if err = reconcileLocalInterfaces(&effectivePlan, operations, options.PodUID); err != nil {
 		return err
 	}
@@ -1510,6 +1514,12 @@ func waitForConnectivityRevisions(
 			if err := reconcileInterposition(basePlan, options, operations); err != nil {
 				return err
 			}
+
+			// Re-asserting the owned hosts entries every tick delivers peer-directory updates
+			// to a running Pod (lab membership changes never restart Pods) and heals the
+			// kubelet's file rewrite after any container (re)start. The write only happens
+			// when the realized content differs.
+			assertOwnedHosts(basePlan)
 
 			nextRevision, nextReady, err := applyProjectedConnectivityRevision(
 				ctx,

--- a/internal/directruntime/imported_runtime.go
+++ b/internal/directruntime/imported_runtime.go
@@ -87,6 +87,10 @@ func newImportedApplicationRuntime(
 			runtime.management = &clabtypes.MgmtNet{
 				IPv4Gw: management.IPv4Gateway,
 				IPv6Gw: management.IPv6Gateway,
+				// Imported packages size their management interface from the runtime's
+				// management network. The realized path is bounded by the Pod underlay minus
+				// the mesh encapsulation, well below the 1500 bytes a device assumes.
+				MTU: clabernetesinternaldeviceplan.ManagementPathMTU(plan, runtime.target.NodeID),
 			}
 		}
 	}

--- a/internal/directruntime/interposition_linux.go
+++ b/internal/directruntime/interposition_linux.go
@@ -230,6 +230,13 @@ func (o netlinkOperations) EnsureInterposition(spec InterpositionSpec) error {
 		return err
 	}
 
+	// A device whose management port size is fixed by the application cannot be told the mesh
+	// MTU; clamping the segment size the handshake advertises keeps its management flows inside
+	// what the mesh carries.
+	if err := ensureMeshSegmentClamp(meshMTU); err != nil {
+		return err
+	}
+
 	if err := applyInterpositionSysctls(spec); err != nil {
 		return err
 	}

--- a/internal/directruntime/launch.go
+++ b/internal/directruntime/launch.go
@@ -23,6 +23,11 @@ const conventionalNoFileLimit = 1_048_576
 type LaunchOperations interface {
 	Delay(duration time.Duration) error
 	MountFilesystem(source, destination, filesystem string, options []string) error
+	// UpdateFile rewrites an existing file in place under an exclusive advisory lock; update
+	// receives the current content and returns the desired content plus whether to write.
+	UpdateFile(path string, update func(current []byte) (updated []byte, write bool)) error
+	ReadFile(path string) ([]byte, error)
+	Hostname() (string, error)
 	LimitOpenFiles(limit uint64) error
 	Exec(argv []string) error
 }
@@ -102,6 +107,12 @@ func RunLaunchWithOperations(
 			return fmt.Errorf("pre-start action %q failed: %w", action.ID, err)
 		}
 	}
+
+	applyOwnedHostsBestEffort(
+		normalized,
+		ApplicationPeerDirectoryRoot+"/"+PeerDirectoryConfigMapKey,
+		operations,
+	)
 
 	entrypoint := slices.Clone(target.Entrypoint)
 	if len(entrypoint) == 0 {

--- a/internal/directruntime/launch_linux.go
+++ b/internal/directruntime/launch_linux.go
@@ -5,6 +5,7 @@ package directruntime
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -98,6 +99,59 @@ func (linuxLaunchOperations) MountFilesystem(
 	}
 
 	return nil
+}
+
+func (linuxLaunchOperations) UpdateFile(
+	path string,
+	update func(current []byte) (updated []byte, write bool),
+) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0) //nolint:gosec // fixed runtime-owned path.
+	if err != nil {
+		return fmt.Errorf("opening %q for in-place update: %w", path, err)
+	}
+
+	defer file.Close() //nolint:errcheck // read-modify-write is flushed by the explicit write.
+
+	// The advisory lock serializes sibling launch boundaries in the same Pod; the kubelet does
+	// not take it, but a kubelet rewrite is always followed by the (re)started container's own
+	// launch, which restores the content.
+	//nolint:gosec // kernel-issued fd.
+	if err = unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("locking %q: %w", path, err)
+	}
+
+	//nolint:errcheck,gosec // kernel-issued fd; the lock is released on close anyway.
+	defer unix.Flock(int(file.Fd()), unix.LOCK_UN)
+
+	current, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	updated, write := update(current)
+	if !write {
+		return nil
+	}
+
+	// The file is a bind mount (kubelet-managed), so it cannot be replaced by rename; truncate
+	// and rewrite in place instead.
+	if err = file.Truncate(0); err != nil {
+		return fmt.Errorf("truncating %q: %w", path, err)
+	}
+
+	if _, err = file.WriteAt(updated, 0); err != nil {
+		return fmt.Errorf("rewriting %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func (linuxLaunchOperations) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path) //nolint:gosec // fixed runtime-owned path.
+}
+
+func (linuxLaunchOperations) Hostname() (string, error) {
+	return os.Hostname()
 }
 
 func (linuxLaunchOperations) LimitOpenFiles(limit uint64) error {

--- a/internal/directruntime/launch_other.go
+++ b/internal/directruntime/launch_other.go
@@ -23,6 +23,21 @@ func (unsupportedLaunchOperations) MountFilesystem(_, _, filesystem string, _ []
 	return fmt.Errorf("filesystem operation %q requires Linux", filesystem)
 }
 
+func (unsupportedLaunchOperations) UpdateFile(
+	_ string,
+	_ func(current []byte) (updated []byte, write bool),
+) error {
+	return fmt.Errorf("in-place file updates require Linux")
+}
+
+func (unsupportedLaunchOperations) ReadFile(_ string) ([]byte, error) {
+	return nil, fmt.Errorf("file reads require Linux")
+}
+
+func (unsupportedLaunchOperations) Hostname() (string, error) {
+	return "", fmt.Errorf("application container hostnames require Linux")
+}
+
 func (unsupportedLaunchOperations) LimitOpenFiles(uint64) error {
 	return fmt.Errorf("open-file limits require Linux")
 }

--- a/internal/directruntime/launch_test.go
+++ b/internal/directruntime/launch_test.go
@@ -1,6 +1,8 @@
 package directruntime_test
 
 import (
+	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +12,8 @@ import (
 	clabernetesinternaldirectruntime "github.com/clabernetes/clabernetes/internal/directruntime"
 )
 
+var errHostsFileSealed = errors.New("hosts file is sealed")
+
 type recordingLaunchOperations struct {
 	source      string
 	destination string
@@ -18,6 +22,9 @@ type recordingLaunchOperations struct {
 	delays      []time.Duration
 	argv        []string
 	fileLimits  []uint64
+	hostname    string
+	files       map[string][]byte
+	updateErr   error
 }
 
 func (r *recordingLaunchOperations) Delay(duration time.Duration) error {
@@ -39,6 +46,43 @@ func (r *recordingLaunchOperations) MountFilesystem(
 	r.options = append([]string(nil), options...)
 
 	return nil
+}
+
+func (r *recordingLaunchOperations) UpdateFile(
+	path string,
+	update func(current []byte) (updated []byte, write bool),
+) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+
+	updated, write := update(r.files[path])
+	if write {
+		if r.files == nil {
+			r.files = map[string][]byte{}
+		}
+
+		r.files[path] = updated
+	}
+
+	return nil
+}
+
+func (r *recordingLaunchOperations) ReadFile(path string) ([]byte, error) {
+	content, exists := r.files[path]
+	if !exists {
+		return nil, os.ErrNotExist
+	}
+
+	return content, nil
+}
+
+func (r *recordingLaunchOperations) Hostname() (string, error) {
+	if r.hostname == "" {
+		return "test-host", nil
+	}
+
+	return r.hostname, nil
 }
 
 func (r *recordingLaunchOperations) LimitOpenFiles(limit uint64) error {
@@ -107,6 +151,151 @@ func TestRunLaunchAppliesGenericMountBeforeImageProcess(t *testing.T) {
 		operations.argv,
 		want,
 	) {
+		t.Fatalf("application argv = %#v, want %#v", operations.argv, want)
+	}
+}
+
+func TestRunLaunchPrependsNodeIdentityAheadOfKubeletHostsEntry(t *testing.T) {
+	t.Parallel()
+
+	kubeletHosts := "# Kubernetes-managed hosts file.\n" +
+		"127.0.0.1\tlocalhost\n" +
+		"172.16.79.171\tnode-a\n" +
+		"# Entries added by HostAliases.\n" +
+		"172.90.90.42\tpeer-b\n"
+
+	plan := lifecycleTestPlan()
+	plan.Containers[0].ImageCommand = []string{"run"}
+	plan.Management = []clabernetesinternaldeviceplan.ManagementPlan{{
+		ID: "management/node-a", NodeID: "node-a", InterfaceName: "mgmt0",
+		IPv4: "172.90.90.41/24", IPv6: "fd00:90::41/64",
+	}}
+
+	operations := &recordingLaunchOperations{
+		hostname: "node-a",
+		files:    map[string][]byte{"/etc/hosts": []byte(kubeletHosts)},
+	}
+	if err := clabernetesinternaldirectruntime.RunLaunchWithOperations(
+		plan,
+		"container-a",
+		operations,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "172.90.90.41\tnode-a\t# c9s-node-identity\n" +
+		"fd00:90::41\tnode-a\t# c9s-node-identity\n" +
+		kubeletHosts
+	if got := string(operations.files["/etc/hosts"]); got != want {
+		t.Fatalf("hosts content = %q, want %q", got, want)
+	}
+
+	// A container restart re-runs the launch against already-owned content; the rewrite must
+	// be idempotent rather than stacking identity lines.
+	if err := clabernetesinternaldirectruntime.RunLaunchWithOperations(
+		plan,
+		"container-a",
+		operations,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := string(operations.files["/etc/hosts"]); got != want {
+		t.Fatalf("hosts content after relaunch = %q, want %q", got, want)
+	}
+}
+
+func TestRunLaunchRealizesPeerDirectoryAheadOfKubeletContent(t *testing.T) {
+	t.Parallel()
+
+	directory, err := clabernetesinternaldirectruntime.RenderPeerDirectory(
+		[]clabernetesinternaldirectruntime.PeerIdentity{
+			// The own node's name is identity-owned, but its component alias still resolves.
+			{Name: "node-a", IPv4: "172.90.90.41", Aliases: []string{"node-a-a"}},
+			{Name: "r9", IPv4: "172.90.90.19", IPv6: "fd00:90::19"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubeletHosts := "# Kubernetes-managed hosts file.\n172.16.79.171\tnode-a\n"
+
+	plan := lifecycleTestPlan()
+	plan.Containers[0].ImageCommand = []string{"run"}
+	plan.Management = []clabernetesinternaldeviceplan.ManagementPlan{{
+		ID: "management/node-a", NodeID: "node-a", InterfaceName: "mgmt0",
+		IPv4: "172.90.90.41/24",
+	}}
+
+	operations := &recordingLaunchOperations{
+		hostname: "node-a",
+		files: map[string][]byte{
+			"/etc/hosts": []byte(kubeletHosts),
+			"/var/lib/clabernetes/peer-directory/peers.json": directory,
+		},
+	}
+	if err = clabernetesinternaldirectruntime.RunLaunchWithOperations(
+		plan,
+		"container-a",
+		operations,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "172.90.90.41\tnode-a\t# c9s-node-identity\n" +
+		"172.90.90.41\tnode-a-a\t# c9s-peer\n" +
+		"172.90.90.19\tr9\t# c9s-peer\n" +
+		"fd00:90::19\tr9\t# c9s-peer\n" +
+		kubeletHosts
+	if got := string(operations.files["/etc/hosts"]); got != want {
+		t.Fatalf("hosts content = %q, want %q", got, want)
+	}
+}
+
+func TestRunLaunchSkipsNodeIdentityWithoutManagementAddress(t *testing.T) {
+	t.Parallel()
+
+	plan := lifecycleTestPlan()
+	plan.Containers[0].ImageCommand = []string{"run"}
+
+	operations := &recordingLaunchOperations{hostname: "node-a"}
+	if err := clabernetesinternaldirectruntime.RunLaunchWithOperations(
+		plan,
+		"container-a",
+		operations,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(operations.files) != 0 {
+		t.Fatalf("hosts files written without a management address: %#v", operations.files)
+	}
+}
+
+func TestRunLaunchStartsApplicationWhenNodeIdentityRewriteFails(t *testing.T) {
+	t.Parallel()
+
+	plan := lifecycleTestPlan()
+	plan.Containers[0].ImageCommand = []string{"run"}
+	plan.Management = []clabernetesinternaldeviceplan.ManagementPlan{{
+		ID: "management/node-a", NodeID: "node-a", InterfaceName: "mgmt0",
+		IPv4: "172.90.90.41/24",
+	}}
+
+	operations := &recordingLaunchOperations{
+		hostname:  "node-a",
+		updateErr: errHostsFileSealed,
+	}
+	if err := clabernetesinternaldirectruntime.RunLaunchWithOperations(
+		plan,
+		"container-a",
+		operations,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"run"}; !reflect.DeepEqual(operations.argv, want) {
 		t.Fatalf("application argv = %#v, want %#v", operations.argv, want)
 	}
 }

--- a/internal/directruntime/lifecycle.go
+++ b/internal/directruntime/lifecycle.go
@@ -22,6 +22,9 @@ const (
 	maxLifecycleFileBytes    = 64 << 20
 	maxLifecycleBinaryBytes  = 256 << 20
 	applicationRestartMarker = "request"
+	// containerLogPath is the application process' stdout, which the kubelet collects as the
+	// container log.
+	containerLogPath = "/proc/1/fd/1"
 )
 
 // ApplicationRestartOperations is the narrow process boundary used to restart a kubelet-owned
@@ -315,7 +318,11 @@ func runLifecycle(
 			}
 		case clabernetesinternaldeviceplan.ActionExec:
 			if err = runLifecycleExec(ctx, action); err != nil {
-				return fmt.Errorf("lifecycle action %q failed: %w", action.ID, err)
+				if action.Exec == nil || !action.Exec.ContinueOnError {
+					return fmt.Errorf("lifecycle action %q failed: %w", action.ID, err)
+				}
+
+				reportContinuedLifecycleFailure(normalized, action, err)
 			}
 		case clabernetesinternaldeviceplan.ActionFile:
 			if err = runLifecycleFile(action, files, root); err != nil {
@@ -387,6 +394,49 @@ func runLifecycleExec(ctx context.Context, action clabernetesinternaldeviceplan.
 	process.Stderr = os.Stderr
 
 	return process.Run()
+}
+
+// reportContinuedLifecycleFailure records a lifecycle command that failed without taking its
+// container down. A lifecycle hook's own output is discarded once the hook succeeds, so the
+// report is also written to the application container's log -- the one place an operator reading
+// `kubectl logs` will find it.
+func reportContinuedLifecycleFailure(
+	plan clabernetesinternaldeviceplan.Plan,
+	action clabernetesinternaldeviceplan.Action,
+	failure error,
+) {
+	message := fmt.Sprintf(
+		"c9s: exec command %q on node %q failed and was skipped: %s\n",
+		strings.Join(action.Exec.Command, " "),
+		planNodeName(plan, action.Target.NodeID),
+		failure,
+	)
+
+	_, _ = os.Stderr.WriteString(message)
+
+	// Best effort: PID 1 is the application process the kubelet started, so its stdout is the
+	// container log. A container that does not expose it simply keeps the report on the hook's
+	// own stderr.
+	log, err := os.OpenFile(containerLogPath, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = log.Close() }()
+
+	_, _ = log.WriteString(message)
+}
+
+// planNodeName resolves the containerlab node name behind a plan-internal node identity, so a
+// report names the node its author wrote rather than an opaque identifier.
+func planNodeName(plan clabernetesinternaldeviceplan.Plan, nodeID string) string {
+	for _, node := range plan.Nodes {
+		if node.ID == nodeID && node.Name != "" {
+			return node.Name
+		}
+	}
+
+	return nodeID
 }
 
 func runLifecycleFile(

--- a/internal/directruntime/lifecycle_test.go
+++ b/internal/directruntime/lifecycle_test.go
@@ -182,6 +182,94 @@ func TestRunLifecycleExecutesTypedActionsInsideTargetFilesystem(t *testing.T) {
 	}
 }
 
+// TestRunLifecycleContinuesPastFailingTopologyExec pins the containerlab behavior of the
+// topology's own exec list: a failing command is reported and the rest of the phase still runs.
+// A PostStart hook that failed would take the whole application container down instead.
+func TestRunLifecycleContinuesPastFailingTopologyExec(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "post-start-ran")
+
+	plan := lifecycleTestPlan()
+	plan.Actions = []clabernetesinternaldeviceplan.Action{
+		{
+			ID: "post-start/node-a/0", Phase: clabernetesinternaldeviceplan.PhasePostStart,
+			Order: 1,
+			Target: clabernetesinternaldeviceplan.ActionTarget{
+				NodeID: "node-a", ContainerID: "container-a",
+			},
+			Kind: clabernetesinternaldeviceplan.ActionExec,
+			Exec: &clabernetesinternaldeviceplan.ExecAction{
+				Command:         []string{"/bin/sh", "-c", "exit 7"},
+				Wait:            true,
+				ContinueOnError: true,
+			},
+		},
+		{
+			ID: "post-start/node-a/1", Phase: clabernetesinternaldeviceplan.PhasePostStart,
+			Order: 2,
+			Target: clabernetesinternaldeviceplan.ActionTarget{
+				NodeID: "node-a", ContainerID: "container-a",
+			},
+			Kind: clabernetesinternaldeviceplan.ActionExec,
+			Exec: &clabernetesinternaldeviceplan.ExecAction{
+				Command:         []string{"/bin/sh", "-c", "printf complete > " + marker},
+				Wait:            true,
+				ContinueOnError: true,
+			},
+		},
+	}
+
+	if err := clabernetesinternaldirectruntime.RunLifecycle(
+		context.Background(),
+		plan,
+		clabernetesinternaldeviceplan.PhasePostStart,
+		"container-a",
+		root,
+	); err != nil {
+		t.Fatalf("RunLifecycle() error = %v, want the failing exec command to be skipped", err)
+	}
+
+	if markerContent, err := os.ReadFile(marker); err != nil || //nolint:gosec // test-controlled path.
+		string(markerContent) != "complete" {
+		t.Fatalf("post-start marker = %q, %v", markerContent, err)
+	}
+}
+
+// TestRunLifecycleFailsOnFailingImportedExec keeps the commands a kind's own deployment recorded
+// fail-closed: those are part of bringing the node up, not user-declared best-effort work.
+func TestRunLifecycleFailsOnFailingImportedExec(t *testing.T) {
+	t.Parallel()
+
+	plan := lifecycleTestPlan()
+	plan.Actions = []clabernetesinternaldeviceplan.Action{
+		{
+			ID:    "imported-deploy-exec/node-a/000001",
+			Phase: clabernetesinternaldeviceplan.PhasePostStart,
+			Order: 1,
+			Target: clabernetesinternaldeviceplan.ActionTarget{
+				NodeID: "node-a", ContainerID: "container-a",
+			},
+			Kind: clabernetesinternaldeviceplan.ActionExec,
+			Exec: &clabernetesinternaldeviceplan.ExecAction{
+				Command: []string{"/bin/sh", "-c", "exit 7"}, Wait: true,
+			},
+		},
+	}
+
+	err := clabernetesinternaldirectruntime.RunLifecycle(
+		context.Background(),
+		plan,
+		clabernetesinternaldeviceplan.PhasePostStart,
+		"container-a",
+		t.TempDir(),
+	)
+	if err == nil {
+		t.Fatal("RunLifecycle() error = nil, want the failing imported command to fail the phase")
+	}
+}
+
 func TestRunLifecycleRejectsCrossNodeArtifactAccess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/directruntime/nodeidentityhosts.go
+++ b/internal/directruntime/nodeidentityhosts.go
@@ -1,0 +1,210 @@
+package directruntime
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
+)
+
+// nodeIdentityHostsMarker tags the hosts line carrying the Pod's own node identity, and
+// peerHostsMarker tags the namespace peer entries; a rewrite replaces exactly the marked lines
+// without disturbing kubelet- or package-written content.
+const (
+	nodeIdentityHostsMarker = "# c9s-node-identity"
+	peerHostsMarker         = "# c9s-peer"
+)
+
+// podHostsFilePath is the kubelet-managed hosts file bind-mounted into every container of the
+// Pod; a write from any container is visible in all of them.
+const podHostsFilePath = "/etc/hosts"
+
+// applyOwnedHostsBestEffort realizes the c9s-owned hosts entries: the Pod's own node name
+// resolves to its management address (the kubelet writes "<podIP> <hostname>" first and the
+// first match wins, so the owned line is prepended ahead of it), and every namespace peer —
+// with its aliases and chassis component names — resolves to its management address, so peer
+// traffic rides the management mesh on any port, exactly like the Docker management network.
+// The peer set comes from the mounted peer-directory file, so lab membership changes reach a
+// running Pod without a restart. Best effort by design: a failed rewrite leaves the kubelet's
+// resolution in place and must not keep the device from booting.
+func applyOwnedHostsBestEffort(
+	plan clabernetesinternaldeviceplan.Plan,
+	peerDirectoryPath string,
+	operations LaunchOperations,
+) {
+	hostname, err := operations.Hostname()
+	if err != nil {
+		reportSkippedOwnedHosts(err)
+
+		return
+	}
+
+	peers := []PeerIdentity(nil)
+
+	if peerDirectoryPath != "" {
+		content, readErr := operations.ReadFile(peerDirectoryPath)
+		if readErr == nil && len(content) != 0 {
+			peers, readErr = ParsePeerDirectory(content)
+		}
+
+		if readErr != nil && !os.IsNotExist(readErr) {
+			// The directory is an optional projection: absence means no peers yet.
+			reportSkippedOwnedHosts(readErr)
+		}
+	}
+
+	identity := renderNodeIdentityHostsLines(plan, hostname)
+	peerLines := renderPeerHostsLines(peers, hostname)
+
+	if identity == "" && peerLines == "" {
+		return
+	}
+
+	err = operations.UpdateFile(
+		podHostsFilePath,
+		func(current []byte) ([]byte, bool) {
+			updated := prependOwnedHosts(current, identity+peerLines)
+
+			return updated, !bytes.Equal(current, updated)
+		},
+	)
+	if err != nil {
+		reportSkippedOwnedHosts(err)
+	}
+}
+
+// renderNodeIdentityHostsLines renders the c9s-owned hosts lines for the Pod's primary node,
+// or "" when the hostname names no planned node or the node has no management address.
+func renderNodeIdentityHostsLines(
+	plan clabernetesinternaldeviceplan.Plan,
+	hostname string,
+) string {
+	nodeID := ""
+
+	for _, node := range plan.Nodes {
+		if node.Name == hostname {
+			nodeID = node.ID
+
+			break
+		}
+	}
+
+	if nodeID == "" {
+		return ""
+	}
+
+	ipv4 := ""
+	ipv6 := ""
+
+	for _, management := range plan.Management {
+		if management.NodeID != nodeID {
+			continue
+		}
+
+		if address := bareManagementHostsAddress(management.IPv4); address != "" {
+			ipv4 = address
+		}
+
+		if address := bareManagementHostsAddress(management.IPv6); address != "" {
+			ipv6 = address
+		}
+	}
+
+	lines := strings.Builder{}
+
+	for _, address := range []string{ipv4, ipv6} {
+		if address == "" {
+			continue
+		}
+
+		fmt.Fprintf(&lines, "%s\t%s\t%s\n", address, hostname, nodeIdentityHostsMarker)
+	}
+
+	return lines.String()
+}
+
+// renderPeerHostsLines renders the namespace peer entries. The Pod's own hostname is owned by
+// the identity line; the own node's aliases and component names still resolve through its peer
+// entry, and grouped in-Pod names keep their kubelet hostAliases.
+func renderPeerHostsLines(peers []PeerIdentity, hostname string) string {
+	lines := strings.Builder{}
+	seen := map[string]bool{hostname: true}
+
+	for _, peer := range peers {
+		for _, name := range append([]string{peer.Name}, peer.Aliases...) {
+			if name == "" || seen[name] {
+				continue
+			}
+
+			seen[name] = true
+
+			for _, address := range []string{peer.IPv4, peer.IPv6} {
+				if address == "" {
+					continue
+				}
+
+				fmt.Fprintf(&lines, "%s\t%s\t%s\n", address, name, peerHostsMarker)
+			}
+		}
+	}
+
+	return lines.String()
+}
+
+func bareManagementHostsAddress(cidr string) string {
+	if cidr == "" {
+		return ""
+	}
+
+	address, _, found := strings.Cut(cidr, "/")
+	if !found {
+		return cidr
+	}
+
+	return address
+}
+
+// prependOwnedHosts places the owned lines ahead of everything else and drops any previously
+// written owned lines, leaving all other content untouched.
+func prependOwnedHosts(current []byte, owned string) []byte {
+	kept := strings.Builder{}
+
+	for line := range strings.Lines(string(current)) {
+		if strings.Contains(line, nodeIdentityHostsMarker) ||
+			strings.Contains(line, peerHostsMarker) {
+			continue
+		}
+
+		kept.WriteString(line)
+	}
+
+	remainder := kept.String()
+	if remainder != "" && !strings.HasSuffix(remainder, "\n") {
+		remainder += "\n"
+	}
+
+	return []byte(owned + remainder)
+}
+
+// assertOwnedHosts is the sidecar-side entry: the connectivity sidecar shares the Pod's UTS
+// hostname and the kubelet-managed hosts file, so it realizes the same owned entries as the
+// launch boundary, from the sidecar's own peer-directory mount.
+func assertOwnedHosts(plan clabernetesinternaldeviceplan.Plan) {
+	applyOwnedHostsBestEffort(
+		plan,
+		ConnectivityPeerDirectoryRoot+"/"+PeerDirectoryConfigMapKey,
+		newLaunchOperations(),
+	)
+}
+
+// reportSkippedOwnedHosts notes a best-effort hosts rewrite failure on the container's own log
+// stream; the device still runs, resolving names the way the kubelet left them.
+func reportSkippedOwnedHosts(err error) {
+	fmt.Fprintf(
+		os.Stderr,
+		"c9s: owned hosts entries skipped, name resolution falls back to kubelet content: %v\n",
+		err,
+	)
+}

--- a/internal/directruntime/peerdirectory.go
+++ b/internal/directruntime/peerdirectory.go
@@ -1,0 +1,79 @@
+package directruntime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// The peer directory is the namespace-wide map of logical node names onto management
+// addresses. It rides one namespace-scoped ConfigMap mounted into every device Pod, so lab
+// membership changes reach running Pods through the kubelet's ConfigMap sync — no Deployment
+// change, no Pod restart. The launch boundary realizes it into /etc/hosts before the device
+// process starts, and the connectivity sidecar re-asserts it while the Pod runs.
+const (
+	// PeerDirectoryConfigMapName is the namespace-scoped ConfigMap carrying the directory.
+	PeerDirectoryConfigMapName = "c9s-peer-directory"
+	// PeerDirectoryConfigMapKey is the single file key inside that ConfigMap.
+	PeerDirectoryConfigMapKey = "peers.json"
+	// ApplicationPeerDirectoryRoot is where application containers mount the directory.
+	ApplicationPeerDirectoryRoot = "/var/lib/clabernetes/peer-directory"
+	// ConnectivityPeerDirectoryRoot is where the connectivity sidecar mounts the directory.
+	ConnectivityPeerDirectoryRoot = "/var/run/clabernetes/peer-directory"
+	// peerDirectorySchemaVersion gates forward-incompatible directory changes.
+	peerDirectorySchemaVersion = 1
+)
+
+// errUnsupportedPeerDirectory marks directory content from an incompatible schema.
+var errUnsupportedPeerDirectory = errors.New("unsupported peer directory")
+
+// PeerIdentity is one logical node's resolvable identity: its name, the extra names Docker DNS
+// would also resolve (declared aliases and chassis component runtime names), and its bare
+// management addresses.
+type PeerIdentity struct {
+	Name    string   `json:"name"`
+	IPv4    string   `json:"ipv4,omitempty"`
+	IPv6    string   `json:"ipv6,omitempty"`
+	Aliases []string `json:"aliases,omitempty"`
+}
+
+// PeerDirectory is the serialized namespace directory.
+type PeerDirectory struct {
+	SchemaVersion int            `json:"schemaVersion"`
+	Peers         []PeerIdentity `json:"peers,omitempty"`
+}
+
+// RenderPeerDirectory serializes the directory deterministically (sorted by peer name) so
+// repeated reconciles of unchanged content produce identical bytes.
+func RenderPeerDirectory(peers []PeerIdentity) ([]byte, error) {
+	sorted := slices.Clone(peers)
+	slices.SortFunc(sorted, func(left, right PeerIdentity) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	return json.Marshal(PeerDirectory{
+		SchemaVersion: peerDirectorySchemaVersion,
+		Peers:         sorted,
+	})
+}
+
+// ParsePeerDirectory deserializes a directory, rejecting content from a newer schema.
+func ParsePeerDirectory(content []byte) ([]PeerIdentity, error) {
+	directory := PeerDirectory{}
+	if err := json.Unmarshal(content, &directory); err != nil {
+		return nil, fmt.Errorf("parsing peer directory: %w", err)
+	}
+
+	if directory.SchemaVersion != peerDirectorySchemaVersion {
+		return nil, fmt.Errorf(
+			"%w: schema %d is not the supported %d",
+			errUnsupportedPeerDirectory,
+			directory.SchemaVersion,
+			peerDirectorySchemaVersion,
+		)
+	}
+
+	return directory.Peers, nil
+}

--- a/internal/directruntime/segmentclamp_linux.go
+++ b/internal/directruntime/segmentclamp_linux.go
@@ -1,0 +1,162 @@
+//go:build linux
+
+package directruntime
+
+import (
+	"fmt"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"golang.org/x/sys/unix"
+)
+
+// meshSegmentClampTableName is the sidecar-owned bridge-family nftables table holding the
+// management mesh segment clamp. nftables tables are scoped to the Pod network namespace, so the
+// name cannot collide across Pods.
+const meshSegmentClampTableName = "c9s-mesh-clamp"
+
+const (
+	// tcpOptionMaxSegment is TCPOPT_MAXSEG, the option carrying the largest segment a peer is
+	// willing to receive.
+	tcpOptionMaxSegment = 2
+	// tcpOptionMaxSegmentValueOffset and tcpOptionMaxSegmentValueLength locate the size inside
+	// the option (kind and length precede it).
+	tcpOptionMaxSegmentValueOffset = 2
+	tcpOptionMaxSegmentValueLength = 2
+
+	ipv4HeaderBytes = 20
+	ipv6HeaderBytes = 40
+	tcpHeaderBytes  = 20
+	tcpFlagsOffset  = 13
+	tcpFlagSYN      = 0x02
+	etherTypeLength = 2
+)
+
+// ensureMeshSegmentClamp reconciles the segment clamp on the management mesh: every TCP handshake
+// crossing the mesh bridge advertises at most the segment the mesh MTU can carry.
+//
+// Devices whose management port size is fixed by the application (SR OS presents a 1514 byte port
+// that cannot be lowered) otherwise derive their segment size from their own interface and emit
+// frames the mesh cannot carry. Nothing on the path answers with fragmentation-needed -- the drop
+// happens on a veth, not a router -- so the flow becomes a black hole: the connection completes
+// and then stalls on the first full-size segment, which is exactly what a TLS certificate or a
+// NETCONF hello is. Clamping the advertised size makes both peers send segments that fit.
+//
+// The clamp only ever lowers an advertised size, and it is scoped to the mesh bridge so lab data
+// plane traffic keeps whatever segment size the topology asked for.
+func ensureMeshSegmentClamp(meshMTU int) error {
+	if meshMTU <= 0 {
+		return nil
+	}
+
+	conn := &nftables.Conn{}
+
+	table := conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyBridge,
+		Name:   meshSegmentClampTableName,
+	})
+	conn.FlushTable(table)
+
+	chain := conn.AddChain(&nftables.Chain{
+		Name:     "forward",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookForward,
+		Priority: nftables.ChainPriorityFilter,
+	})
+
+	for _, family := range []struct {
+		etherType   uint16
+		headerBytes int
+	}{
+		{etherType: unix.ETH_P_IP, headerBytes: ipv4HeaderBytes},
+		{etherType: unix.ETH_P_IPV6, headerBytes: ipv6HeaderBytes},
+	} {
+		maxSegment := meshMTU - family.headerBytes - tcpHeaderBytes
+		if maxSegment <= 0 {
+			continue
+		}
+
+		conn.AddRule(meshSegmentClampRule(
+			table,
+			chain,
+			family.etherType,
+			uint16(maxSegment), //nolint:gosec // Bounded by the mesh MTU, which is a DNS-sized int.
+		))
+	}
+
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("programming management mesh segment clamp: %w", err)
+	}
+
+	return nil
+}
+
+// meshSegmentClampRule builds the clamp for one address family: a TCP SYN crossing the mesh
+// bridge whose advertised maximum segment exceeds what the mesh carries has that size replaced.
+func meshSegmentClampRule(
+	table *nftables.Table,
+	chain *nftables.Chain,
+	etherType uint16,
+	maxSegment uint16,
+) *nftables.Rule {
+	size := binaryutil.BigEndian.PutUint16(maxSegment)
+
+	return &nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: []expr.Any{
+			// Only frames the mesh bridge forwards; the lab data plane never crosses it.
+			&expr.Meta{Key: expr.MetaKeyBRIIIFNAME, Register: 1},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     interfaceName(MeshBridgeName),
+			},
+			&expr.Meta{Key: expr.MetaKeyPROTOCOL, Register: 1},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint16(etherType)[:etherTypeLength],
+			},
+			// The transport protocol comes from the packet parse rather than a header offset:
+			// the bridge family carries the link header, so the network-header offsets differ
+			// per address family and per IPv6 extension chain.
+			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       tcpFlagsOffset,
+				Len:          1,
+			},
+			&expr.Bitwise{
+				SourceRegister: 1,
+				DestRegister:   1,
+				Len:            1,
+				Mask:           []byte{tcpFlagSYN},
+				Xor:            []byte{0x00},
+			},
+			&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{0x00}},
+			// A SYN without the option carries no size to clamp and stops matching here.
+			&expr.Exthdr{
+				DestRegister: 1,
+				Type:         tcpOptionMaxSegment,
+				Offset:       tcpOptionMaxSegmentValueOffset,
+				Len:          tcpOptionMaxSegmentValueLength,
+				Op:           expr.ExthdrOpTcpopt,
+			},
+			// Never raise a peer that already asked for less than the mesh carries.
+			&expr.Cmp{Op: expr.CmpOpGt, Register: 1, Data: size},
+			&expr.Immediate{Register: 1, Data: size},
+			&expr.Exthdr{
+				SourceRegister: 1,
+				Type:           tcpOptionMaxSegment,
+				Offset:         tcpOptionMaxSegmentValueOffset,
+				Len:            tcpOptionMaxSegmentValueLength,
+				Op:             expr.ExthdrOpTcpopt,
+			},
+		},
+	}
+}

--- a/internal/directruntime/segmentclamp_linux_test.go
+++ b/internal/directruntime/segmentclamp_linux_test.go
@@ -1,0 +1,193 @@
+//go:build linux
+
+//nolint:testpackage // the clamp is an internal boundary exercised end to end.
+package directruntime
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+)
+
+const segmentClampNetlinkChild = "C9S_SEGMENT_CLAMP_NETLINK_TEST_CHILD"
+
+// TestMeshSegmentClampProgramsOwnedTableInIsolatedNamespace programs the real backend, so the
+// kernel itself confirms the clamp is expressible: a rejected expression set fails here rather
+// than silently leaving every management flow black-holed at runtime.
+func TestMeshSegmentClampProgramsOwnedTableInIsolatedNamespace(t *testing.T) {
+	if os.Getenv(segmentClampNetlinkChild) == "1" {
+		testMeshSegmentClampProgramsOwnedTable(t)
+
+		return
+	}
+
+	unshare, err := exec.LookPath("unshare")
+	if err != nil {
+		t.Skip("unshare is unavailable")
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unshareArguments := []string{
+		"-Urn",
+		executable,
+		"-test.run=^TestMeshSegmentClampProgramsOwnedTableInIsolatedNamespace$",
+	}
+	if os.Geteuid() == 0 {
+		unshareArguments[0] = "-n"
+	}
+
+	command := exec.CommandContext( //nolint:gosec // The current test binary is executed in a new namespace.
+		t.Context(),
+		unshare,
+		unshareArguments...,
+	)
+
+	command.Env = append(os.Environ(), segmentClampNetlinkChild+"=1")
+
+	output, err := command.CombinedOutput()
+	if err != nil {
+		if strings.Contains(strings.ToLower(string(output)), "operation not permitted") {
+			t.Skip(
+				"the kernel restricts required netlink operations in an unprivileged user namespace",
+			)
+		}
+
+		t.Fatalf("isolated segment clamp programming test failed: %v\n%s", err, output)
+	}
+}
+
+func testMeshSegmentClampProgramsOwnedTable(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+
+	const meshMTU = 1430
+
+	if err := ensureMeshSegmentClamp(meshMTU); err != nil {
+		t.Fatalf("programming segment clamp: %v", err)
+	}
+
+	// Reconciling twice must be idempotent and leave exactly one table with the same rules.
+	if err := ensureMeshSegmentClamp(meshMTU); err != nil {
+		t.Fatalf("reprogramming segment clamp: %v", err)
+	}
+
+	conn := &nftables.Conn{}
+
+	tables, err := conn.ListTablesOfFamily(nftables.TableFamilyBridge)
+	if err != nil {
+		t.Fatalf("listing bridge tables: %v", err)
+	}
+
+	var owned *nftables.Table
+
+	for _, table := range tables {
+		if table.Name == meshSegmentClampTableName {
+			owned = table
+		}
+	}
+
+	if owned == nil {
+		t.Fatal("owned segment clamp table was not created")
+	}
+
+	chains, err := conn.ListChainsOfTableFamily(nftables.TableFamilyBridge)
+	if err != nil {
+		t.Fatalf("listing bridge chains: %v", err)
+	}
+
+	var forward *nftables.Chain
+
+	for _, chain := range chains {
+		if chain.Table.Name == meshSegmentClampTableName && chain.Name == "forward" {
+			forward = chain
+		}
+	}
+
+	if forward == nil {
+		t.Fatal("segment clamp forward chain was not created")
+	}
+
+	rules, err := conn.GetRules(owned, forward)
+	if err != nil {
+		t.Fatalf("listing segment clamp rules: %v", err)
+	}
+
+	if len(rules) != 2 {
+		t.Fatalf("expected one clamp rule per address family, got %d", len(rules))
+	}
+
+	for _, rule := range rules {
+		assertClampRuleShape(t, rule)
+	}
+}
+
+// assertClampRuleShape pins the expression shape that was verified to actually rewrite a
+// handshake on the wire. The bridge family carries the link header, so the transport protocol has
+// to come from the packet parse (meta l4proto) rather than a network-header offset: a rule that
+// reads the protocol out of the header at an IPv4 offset is accepted by the kernel and then
+// silently never matches.
+func assertClampRuleShape(t *testing.T, rule *nftables.Rule) {
+	t.Helper()
+
+	var (
+		matchesL4Proto   bool
+		matchesEtherType bool
+		readsMaxSegment  bool
+		writesMaxSegment bool
+	)
+
+	for _, expression := range rule.Exprs {
+		switch typed := expression.(type) {
+		case *expr.Meta:
+			if typed.Key == expr.MetaKeyL4PROTO {
+				matchesL4Proto = true
+			}
+
+			if typed.Key == expr.MetaKeyPROTOCOL {
+				matchesEtherType = true
+			}
+		case *expr.Payload:
+			if typed.Base == expr.PayloadBaseNetworkHeader {
+				t.Fatal("clamp rule reads the network header, which the bridge family offsets differently")
+			}
+		case *expr.Exthdr:
+			if typed.Type != tcpOptionMaxSegment {
+				continue
+			}
+
+			if typed.SourceRegister != 0 {
+				writesMaxSegment = true
+			} else {
+				readsMaxSegment = true
+			}
+		}
+	}
+
+	if !matchesL4Proto || !matchesEtherType || !readsMaxSegment || !writesMaxSegment {
+		t.Fatalf(
+			"clamp rule is incomplete (l4proto %t, ethertype %t, read %t, write %t)",
+			matchesL4Proto, matchesEtherType, readsMaxSegment, writesMaxSegment,
+		)
+	}
+}
+
+// TestMeshSegmentClampIsSkippedWithoutAMeshMTU keeps an unknown path size from programming a
+// clamp of zero, which would make every handshake advertise nothing usable.
+func TestMeshSegmentClampIsSkippedWithoutAMeshMTU(t *testing.T) {
+	t.Parallel()
+
+	if err := ensureMeshSegmentClamp(0); err != nil {
+		t.Fatalf("ensureMeshSegmentClamp(0) error = %v, want no programming at all", err)
+	}
+}

--- a/util/kubernetes/names.go
+++ b/util/kubernetes/names.go
@@ -69,3 +69,45 @@ func EnforceDNSLabelConvention(s string) string {
 
 	return s
 }
+
+const (
+	// nameDigestLen is the number of digest characters appended to a name that had to be
+	// truncated to fit NameMaxLen.
+	nameDigestLen = 7
+	// leadingLetterPrefix prefixes a name that would otherwise start with a digit or a dash,
+	// which a DNS-1035 label cannot do.
+	leadingLetterPrefix = "clab-"
+)
+
+// nonNameChars matches every run of characters a DNS label cannot carry, once the name has been
+// lower-cased.
+var nonNameChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// SanitizeName maps a containerlab name onto the DNS-1035 label Kubernetes can name an object
+// with: lower case, made up of a-z, 0-9 and '-', starting with a letter and at most 63 characters
+// long. A large share of public labs name their nodes R1/PE_1, and Kubernetes cannot carry those
+// names as they are.
+//
+// Unlike EnforceDNSLabelConvention this never rewrites a character a DNS label can carry, so a
+// name Kubernetes already accepts maps onto itself and the mapping is idempotent. The result is
+// empty only for a name holding nothing a Kubernetes name can be built from.
+func SanitizeName(name string) string {
+	sanitized := strings.Trim(nonNameChars.ReplaceAllString(strings.ToLower(name), "-"), "-")
+	if sanitized == "" {
+		return ""
+	}
+
+	if sanitized[0] < 'a' || sanitized[0] > 'z' {
+		sanitized = leadingLetterPrefix + sanitized
+	}
+
+	if len(sanitized) > NameMaxLen {
+		digest := sha256.Sum256([]byte(name))
+		sanitized = strings.TrimRight(
+			sanitized[:NameMaxLen-nameDigestLen-1],
+			"-",
+		) + "-" + hex.EncodeToString(digest[:])[:nameDigestLen]
+	}
+
+	return sanitized
+}

--- a/util/kubernetes/names_test.go
+++ b/util/kubernetes/names_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"strings"
 	"testing"
 
 	clabernetestesthelper "github.com/clabernetes/clabernetes/testhelper"
@@ -139,5 +140,48 @@ func TestEnforceDNSLabelConvention(t *testing.T) {
 					clabernetestesthelper.FailOutput(t, actual, testCase.expected)
 				}
 			})
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"r1":            "r1",
+		"R1":            "r1",
+		"PE_1":          "pe-1",
+		"Spine-01":      "spine-01",
+		"node one":      "node-one",
+		"7750-SR":       "clab-7750-sr",
+		"-leaf-":        "leaf",
+		"srv6+flexalgo": "srv6-flexalgo",
+		"___":           "",
+	}
+
+	for name, want := range cases {
+		got := clabernetesutilkubernetes.SanitizeName(name)
+		if got != want {
+			t.Fatalf("SanitizeName(%q) = %q, want %q", name, got, want)
+		}
+
+		if again := clabernetesutilkubernetes.SanitizeName(got); again != got {
+			t.Fatalf("SanitizeName(%q) = %q, want the sanitized name to be stable", got, again)
+		}
+	}
+}
+
+func TestSanitizeNameTruncatesToADNSLabel(t *testing.T) {
+	long := strings.Repeat("Router", 20)
+
+	got := clabernetesutilkubernetes.SanitizeName(long)
+	if len(got) != clabernetesutilkubernetes.NameMaxLen {
+		t.Fatalf("len(SanitizeName(long)) = %d, want %d",
+			len(got), clabernetesutilkubernetes.NameMaxLen)
+	}
+
+	if again := clabernetesutilkubernetes.SanitizeName(got); again != got {
+		t.Fatalf("SanitizeName(%q) = %q, want the sanitized name to be stable", got, again)
+	}
+
+	if other := clabernetesutilkubernetes.SanitizeName(long + "X"); other == got {
+		t.Fatal("truncated names of different nodes must not collapse onto one name")
 	}
 }

--- a/util/kubernetes/reservedpaths.go
+++ b/util/kubernetes/reservedpaths.go
@@ -1,0 +1,34 @@
+package kubernetes
+
+import (
+	"path"
+	"strings"
+)
+
+// ReservedContainerPathReason reports whether an absolute container path is owned by the
+// kubelet or the direct runtime, and why. The returned reason is suitable for a diagnostic.
+// A user bind or payload landing on a reserved path either renders an invalid Deployment (the
+// kubelet already mounts the path in every container) or silently shadows Pod- or
+// runtime-managed content, so both are rejected with a diagnostic instead of failing at the
+// API server or misbehaving at runtime.
+func ReservedContainerPathReason(value string) (string, bool) {
+	cleaned := path.Clean(value)
+
+	switch cleaned {
+	case "/etc/hosts", "/etc/hostname", "/etc/resolv.conf", "/dev/termination-log":
+		return "the kubelet manages this file in every container; it cannot be bind-mounted",
+			true
+	}
+
+	for _, prefix := range []string{
+		"/var/lib/clabernetes",
+		"/var/run/clabernetes",
+		"/var/run/secrets/kubernetes.io/serviceaccount",
+	} {
+		if cleaned == prefix || strings.HasPrefix(cleaned, prefix+"/") {
+			return "the direct runtime owns this path inside device containers", true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
Running well-known public containerlab labs against the direct runtime surfaced a set of gaps between Docker semantics and what c9s realizes. This branch closes them; with it, the following labs run end to end on a real cluster:

- [martimy/clab-bgp-frr](https://github.com/martimy/clab-bgp-frr) — unmodified
- [srl-labs/srlinux-vlan-handling-lab](https://github.com/srl-labs/srlinux-vlan-handling-lab) — unmodified, full gNMI/VLAN workflow, no MTU workaround
- [sros-labs/srv6-flexalgo-telemetry-lab](https://github.com/srl-labs/srv6-flexalgo-telemetry-lab) — unmodified: 10/10 nodes, gnmic → prometheus → grafana fully fed from all five SR-SIM routers, SRv6 data plane clean
- [srl-labs/sros-anysec-macsec-lab](https://github.com/srl-labs/sros-anysec-macsec-lab) — one edit (the `stages` block, still unsupported): 12/12 nodes including the automation panel, ANYSec verified on all three services by the lab's own tooling

### What's in here

**Names sanitized instead of rejected** (`feat: sanitize node names Kubernetes cannot carry`). `R1..R5` is the most common naming convention in public labs; names Kubernetes cannot carry are now mapped deterministically (lab name, node keys, links, `network-mode`, node-keyed policy, staged mounts) with collisions kept as errors.

**A failing topology `exec` no longer kills the node** (`fix: keep a failing topology exec command from taking the node down`). Kubernetes kills a container whose postStart hook fails; a lab's broken `exec:` line put the node into CrashLoopBackOff where Docker containerlab logs and moves on. Topology exec commands are best effort now, with the failure written to the container log.

**Management flows sized to what the mesh carries** (`fix: size management flows to what the management mesh carries`). The 1430-byte management path was a PMTU black hole that stalled every TLS/NETCONF exchange and permanently wedged SR-SIM's management port. Devices that take an MTU from the runtime get the real value; an MSS clamp on the mesh bridge sizes every TCP management flow for devices that cannot be told (SR OS's fixed 1514 port).

**Reserved container paths rejected with the path named, and Deployment apply failures surfaced** (`fix: reject reserved container paths...`). A bind at `/etc/hosts` used to render an invalid Deployment whose rejection was visible only in the manager log — no Node status, `clab deploy` hanging to timeout. Now: compile-time rejection naming the path, the same check at plan time for hand-written CRs, duplicate-mount de-duplication plus a render invariant, and any API-server rejection stamped on the Node as `PlanApplied=False/DeploymentInvalid`, which the CLI treats as terminal.

**Content-identical grouped payloads no longer conflict** (`fix: tolerate content-identical payload declarations across grouped nodes`). A license inherited by both members of a grouped distributed router was rejected as a payload conflict because the signature included the ConfigMap reference; the signature is content identity now.

**Docker-parity name resolution** (`feat: resolve node and peer names to management addresses`). A node's own name resolved to the Pod IP (a service bound to `gnmic:9804` answered on an address nothing dials) and peer names resolved to per-node Services carrying only declared ports (`prometheus → gnmic:9273` and the anysec panel's `pe1-a:57400` dialed into nothing). Both are realized in the Pod's shared `/etc/hosts`: the launch boundary writes the node's own identity before the device process starts, and a namespace-scoped peer-directory ConfigMap (names, aliases, chassis component names → management addresses) is realized at launch and re-asserted by the connectivity sidecar. Deliberately not `hostAliases`: a lab membership change must never rewrite Deployments and reboot the lab. Verified live — adding a node to a running lab made it resolvable from running peers in under a minute with zero Pod recreations, and removing it cleaned up the same way. VM-based kinds verified unaffected (`juniper_vjunosevolved`: SSH into the guest by name, boot undisturbed).

### Validation

Unit tests accompany each change (name sanitizing, exec best-effort, MSS clamp backend shape, reserved paths at compile/plan/render, payload identity, hosts rewrite idempotency, peer-directory format/reconcile, renderer volume contract). Everything above was additionally verified end to end on a 3-node kubeadm cluster (Calico/IPIP) with the labs listed, including cross-worker management, live lab membership changes, and a QEMU-based kind.

A one-commit containerlab follow-through (branch `c9s`) treats `DeploymentInvalid` as a terminal wait reason.
