### PR TITLE
fix: make direct management MTU portable on vcluster/Talos

### DIFF
--- a/docs/guides/mtu.md
+++ b/docs/guides/mtu.md
@@ -63,9 +63,12 @@ a leg of the per-namespace management mesh, which rides the Pod network encapsul
 carries the Pod network MTU minus that encapsulation (about 1430 bytes on a 1500-byte Pod
 network). Two things keep that from surprising a device:
 
-- **The size is reported to the device.** A kind that configures its management interface from
-  the runtime's management network (SR Linux sets `mgmt0.0 ip-mtu`) receives the size the mesh
-  actually carries instead of assuming 1500.
+- **The size is reported safely to the device.** A kind that configures its management interface
+  from the runtime's management network (SR Linux sets `mgmt0.0 ip-mtu`) receives the smaller of
+  the mesh capacity and the conventional 1500-byte management IP MTU. A smaller mesh is therefore
+  honored, while a jumbo Pod network does not cause a device whose default management port is
+  1514 bytes to receive an invalid jumbo IP MTU. Raising a device management port above its
+  default is not currently part of the generic c9s contract.
 - **Management TCP handshakes are clamped to it.** Some devices present a management port whose
   size the application fixes and cannot lower (SR OS presents 1514). Their handshakes crossing
   the mesh have the advertised maximum segment lowered to what the mesh carries, so both peers

--- a/internal/deviceplan/management_internal_test.go
+++ b/internal/deviceplan/management_internal_test.go
@@ -138,3 +138,25 @@ func TestDefinitionManagementAddressMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestCapAutomaticManagementIPMTU(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		mtu  int
+		want int
+	}{
+		{name: "path below conventional maximum", mtu: 1450, want: 1450},
+		{name: "path at conventional maximum", mtu: 1500, want: 1500},
+		{name: "jumbo path", mtu: 8084, want: 1500},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := capAutomaticManagementIPMTU(test.mtu); got != test.want {
+				t.Fatalf("capAutomaticManagementIPMTU(%d) = %d, want %d", test.mtu, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/deviceplan/managementmtu.go
+++ b/internal/deviceplan/managementmtu.go
@@ -11,19 +11,28 @@ import (
 // the caller's network namespace.
 const sysfsInterfaceRoot = "/sys/class/net"
 
-// ManagementPathMTU reports the MTU of the management path c9s realized for one logical Node, as
-// the device sees it. The management mesh is bounded by the Pod underlay minus the encapsulation
-// it rides in, which is smaller than the 1500 bytes a device assumes by default -- an imported
-// package that configures its management interface from the runtime's management network then
-// configures the size that actually fits, instead of black-holing every packet above the path
-// MTU (there is no router on the path to answer with fragmentation-needed).
+// maximumAutomaticManagementIPMTU keeps the runtime management value compatible with imported
+// device management ports whose default Ethernet MTU is 1514 bytes. Smaller realized paths remain
+// authoritative; a jumbo Pod underlay must not be advertised as an IP MTU unless the device port
+// was explicitly enlarged as well.
+const maximumAutomaticManagementIPMTU = 1500
+
+// ManagementPathMTU reports the automatic IP MTU advertised to an imported device for one logical
+// Node. It is the realized management mesh capacity, capped at 1500 bytes so a jumbo Pod underlay
+// does not exceed a device management port's conventional default; an imported package that
+// configures its management interface from the runtime's management network then receives a value
+// that fits both the mesh and the default device port.
 //
 // The value is read from the realized interface rather than carried in the plan because the
 // bound depends on the CNI MTU of the Kubernetes node the Pod landed on, which the controller
 // does not know when it plans. A management path this process cannot observe reports 0, which
 // leaves the imported package on its own default.
 func ManagementPathMTU(plan Plan, nodeID string) int {
-	return interfaceMTU(managementInterfaceName(plan, nodeID))
+	return capAutomaticManagementIPMTU(interfaceMTU(managementInterfaceName(plan, nodeID)))
+}
+
+func capAutomaticManagementIPMTU(mtu int) int {
+	return min(mtu, maximumAutomaticManagementIPMTU)
 }
 
 // managementInterfaceName returns the name the device's management interface has in the Pod

--- a/internal/directruntime/segmentclamp_linux.go
+++ b/internal/directruntime/segmentclamp_linux.go
@@ -5,6 +5,7 @@ package directruntime
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
@@ -84,12 +85,17 @@ func ensureMeshSegmentClamp(meshMTU int) error {
 				continue
 			}
 
+			if maxSegment > math.MaxUint16 {
+				maxSegment = math.MaxUint16
+			}
+
+			maxSegmentValue := uint16(maxSegment)
 			conn.AddRule(meshSegmentClampRule(
 				table,
 				chain,
 				ingressName,
 				family.etherType,
-				uint16(maxSegment), //nolint:gosec // Bounded by the mesh MTU, which is a DNS-sized int.
+				maxSegmentValue,
 			))
 		}
 	}

--- a/internal/directruntime/segmentclamp_linux.go
+++ b/internal/directruntime/segmentclamp_linux.go
@@ -3,6 +3,7 @@
 package directruntime
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/nftables"
@@ -66,31 +67,49 @@ func ensureMeshSegmentClamp(meshMTU int) error {
 		Priority: nftables.ChainPriorityFilter,
 	})
 
-	for _, family := range []struct {
-		etherType   uint16
-		headerBytes int
-	}{
-		{etherType: unix.ETH_P_IP, headerBytes: ipv4HeaderBytes},
-		{etherType: unix.ETH_P_IPV6, headerBytes: ipv6HeaderBytes},
+	for _, ingressName := range []string{
+		MeshDevicePortName,
+		MeshGatewayPortName,
+		MeshVTEPName,
 	} {
-		maxSegment := meshMTU - family.headerBytes - tcpHeaderBytes
-		if maxSegment <= 0 {
-			continue
-		}
+		for _, family := range []struct {
+			etherType   uint16
+			headerBytes int
+		}{
+			{etherType: unix.ETH_P_IP, headerBytes: ipv4HeaderBytes},
+			{etherType: unix.ETH_P_IPV6, headerBytes: ipv6HeaderBytes},
+		} {
+			maxSegment := meshMTU - family.headerBytes - tcpHeaderBytes
+			if maxSegment <= 0 {
+				continue
+			}
 
-		conn.AddRule(meshSegmentClampRule(
-			table,
-			chain,
-			family.etherType,
-			uint16(maxSegment), //nolint:gosec // Bounded by the mesh MTU, which is a DNS-sized int.
-		))
+			conn.AddRule(meshSegmentClampRule(
+				table,
+				chain,
+				ingressName,
+				family.etherType,
+				uint16(maxSegment), //nolint:gosec // Bounded by the mesh MTU, which is a DNS-sized int.
+			))
+		}
 	}
 
 	if err := conn.Flush(); err != nil {
+		// MSS clamping is an optimization for kernels that expose bridge-family nftables.
+		// Older kernels may reject that optional family or expression with ENOENT or
+		// EOPNOTSUPP; management connectivity must still use the realized mesh.
+		if isUnsupportedMeshSegmentClampError(err) {
+			return nil
+		}
+
 		return fmt.Errorf("programming management mesh segment clamp: %w", err)
 	}
 
 	return nil
+}
+
+func isUnsupportedMeshSegmentClampError(err error) bool {
+	return errors.Is(err, unix.ENOENT) || errors.Is(err, unix.EOPNOTSUPP)
 }
 
 // meshSegmentClampRule builds the clamp for one address family: a TCP SYN crossing the mesh
@@ -98,6 +117,7 @@ func ensureMeshSegmentClamp(meshMTU int) error {
 func meshSegmentClampRule(
 	table *nftables.Table,
 	chain *nftables.Chain,
+	ingressName string,
 	etherType uint16,
 	maxSegment uint16,
 ) *nftables.Rule {
@@ -107,12 +127,13 @@ func meshSegmentClampRule(
 		Table: table,
 		Chain: chain,
 		Exprs: []expr.Any{
-			// Only frames the mesh bridge forwards; the lab data plane never crosses it.
-			&expr.Meta{Key: expr.MetaKeyBRIIIFNAME, Register: 1},
+			// Match the fixed mesh ingress ports instead of the bridge-specific ibrname key:
+			// Talos enables NF_TABLES_BRIDGE without NFT_BRIDGE_META.
+			&expr.Meta{Key: expr.MetaKeyIIFNAME, Register: 1},
 			&expr.Cmp{
 				Op:       expr.CmpOpEq,
 				Register: 1,
-				Data:     interfaceName(MeshBridgeName),
+				Data:     interfaceName(ingressName),
 			},
 			&expr.Meta{Key: expr.MetaKeyPROTOCOL, Register: 1},
 			&expr.Cmp{

--- a/internal/directruntime/segmentclamp_linux_test.go
+++ b/internal/directruntime/segmentclamp_linux_test.go
@@ -4,6 +4,7 @@
 package directruntime
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
+	"golang.org/x/sys/unix"
 )
 
 const segmentClampNetlinkChild = "C9S_SEGMENT_CLAMP_NETLINK_TEST_CHILD"
@@ -123,12 +125,13 @@ func testMeshSegmentClampProgramsOwnedTable(t *testing.T) {
 		t.Fatalf("listing segment clamp rules: %v", err)
 	}
 
-	if len(rules) != 2 {
-		t.Fatalf("expected one clamp rule per address family, got %d", len(rules))
+	if len(rules) != 6 {
+		t.Fatalf("expected one clamp rule per mesh port and address family, got %d", len(rules))
 	}
 
 	for _, rule := range rules {
 		assertClampRuleShape(t, rule)
+		assertClampRuleUsesGenericIngress(t, rule)
 	}
 }
 
@@ -182,6 +185,27 @@ func assertClampRuleShape(t *testing.T, rule *nftables.Rule) {
 	}
 }
 
+func assertClampRuleUsesGenericIngress(t *testing.T, rule *nftables.Rule) {
+	t.Helper()
+
+	for _, expression := range rule.Exprs {
+		meta, ok := expression.(*expr.Meta)
+		if !ok {
+			continue
+		}
+
+		if meta.Key == expr.MetaKeyBRIIIFNAME {
+			t.Fatal("clamp rule uses the optional bridge-specific meta module")
+		}
+
+		if meta.Key == expr.MetaKeyIIFNAME {
+			return
+		}
+	}
+
+	t.Fatal("clamp rule has no generic ingress interface match")
+}
+
 // TestMeshSegmentClampIsSkippedWithoutAMeshMTU keeps an unknown path size from programming a
 // clamp of zero, which would make every handshake advertise nothing usable.
 func TestMeshSegmentClampIsSkippedWithoutAMeshMTU(t *testing.T) {
@@ -189,5 +213,23 @@ func TestMeshSegmentClampIsSkippedWithoutAMeshMTU(t *testing.T) {
 
 	if err := ensureMeshSegmentClamp(0); err != nil {
 		t.Fatalf("ensureMeshSegmentClamp(0) error = %v, want no programming at all", err)
+	}
+}
+
+func TestUnsupportedMeshSegmentClampErrorsAreOptional(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		unix.ENOENT,
+		unix.EOPNOTSUPP,
+		errors.Join(unix.EOPNOTSUPP, unix.ENOENT),
+	} {
+		if !isUnsupportedMeshSegmentClampError(err) {
+			t.Fatalf("isUnsupportedMeshSegmentClampError(%v) = false, want true", err)
+		}
+	}
+
+	if isUnsupportedMeshSegmentClampError(unix.EINVAL) {
+		t.Fatal("isUnsupportedMeshSegmentClampError(EINVAL) = true, want false")
 	}
 }


### PR DESCRIPTION
## Summary

- Prevent `clabwire` from exiting when the optional bridge-family nftables MSS clamp is unavailable, including the `EOPNOTSUPP`/`ENOENT` behavior seen on vCluster fake-node clusters backed by Talos 1.12.2. fix #316 
- Make the clamp avoid the bridge-specific `ibrname` metadata module by matching the fixed mesh ingress ports with generic `iifname` rules.
- Cap automatically advertised management IP MTU at 1500 bytes while preserving smaller realized mesh MTUs, preventing SR Linux `mgmt0.0` from receiving an invalid jumbo `ip-mtu` against its default 1514-byte parent port.
- Update the MTU guide and add regression coverage.

## Upstream context

- Talos 1.12.2 uses Linux 6.18.5, but its kernel configuration omitted `CONFIG_NF_TABLES_BRIDGE`.
- [Talos issue #12729](https://github.com/siderolabs/talos/issues/12729) documents the missing nftables bridge family and the resulting `Operation not supported` error.
- [siderolabs/pkgs PR #1463](https://github.com/siderolabs/pkgs/pull/1463) backports [commit da46073](https://github.com/siderolabs/pkgs/commit/da460730c1980c178416cd7b20e6d1954ea2a673), enabling `CONFIG_NF_TABLES_BRIDGE`; it is included in [Talos 1.12.4](https://github.com/siderolabs/talos/releases/tag/v1.12.4).
- vCluster documents that unsynchronized nodes are pseudo-nodes whose non-name fields are synthetic: [vCluster node synchronization](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sync/from-host/nodes).

## Test plan

- [x] `go test ./internal/deviceplan ./internal/directruntime ./internal/directpod`
- [x] `GOWORK=off golangci-lint run`
- [x] `make check-docs`
- [ ] Rebuild and roll out the manager image in the vCluster/Talos environment.