### PR TITLE
fix: keep sidecar transport ports accepted across device firewalls

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -191,6 +191,14 @@ identity, and gateway traffic never crosses the mesh. Lab members also resolve e
 node name through namespace-local Services; declared `aliases` add extra headless Services
 bound to the same Pod.
 
+A device that firewalls its own network namespace (EOS installs a default-deny input policy)
+cannot sever these transports: the sidecar keeps accept rules for its mesh and wire UDP ports
+asserted at the head of any packet filter a device programs in the shared namespace, and
+re-asserts them on the reconcile tick when a device rewrites its firewall. On hardware the
+wire carrying management traffic is invisible to a control-plane ACL; these accepts preserve
+exactly that boundary, while the device keeps filtering its own management traffic above the
+transport.
+
 ### Exposing Nodes
 
 Ports listed in a node definition (plus a sensible default set unless auto-expose is

--- a/internal/directruntime/connectivity.go
+++ b/internal/directruntime/connectivity.go
@@ -875,6 +875,10 @@ type ConnectivityOptions struct {
 	// backend and tests inject fakes.
 	NATOperations NATOperations
 
+	// FilterOperations is the transport filter-accept seam; production wiring installs the
+	// nftables backend and tests inject fakes.
+	FilterOperations TransportFilterOperations
+
 	// hostEndpointPacer rate-limits steady-state host endpoint re-assertion; the sidecar owns
 	// drift correction, so unchanged ticks do not need a per-second reconcile fan-out.
 	hostEndpointPacer *hostEndpointPacer
@@ -1118,6 +1122,10 @@ func runConnectivity(
 		options.NATOperations = newNATOperations()
 	}
 
+	if options.FilterOperations == nil {
+		options.FilterOperations = newTransportFilterOperations()
+	}
+
 	if err := validateIdentity(input, plan); err != nil {
 		return err
 	}
@@ -1186,6 +1194,10 @@ func runConnectivity(
 	}
 
 	if err = reconcileInterposition(effectivePlan, options, operations); err != nil {
+		return err
+	}
+
+	if err = reconcileTransportFilter(effectivePlan, options); err != nil {
 		return err
 	}
 
@@ -1512,6 +1524,12 @@ func waitForConnectivityRevisions(
 			// is converged back on the next tick, and an unrecoverable divergence restarts the
 			// sidecar into a full fail-closed cold pass.
 			if err := reconcileInterposition(basePlan, options, operations); err != nil {
+				return err
+			}
+
+			// A device rebuilding its packet filter (EOS rewrites iptables on config changes)
+			// displaces the transport-port accepts; the tick re-asserts them.
+			if err := reconcileTransportFilter(basePlan, options); err != nil {
 				return err
 			}
 

--- a/internal/directruntime/connectivity_test.go
+++ b/internal/directruntime/connectivity_test.go
@@ -604,10 +604,11 @@ func TestConnectivityHelperRestartRecoversEveryLinkFlavor(t *testing.T) {
 				cancel()
 
 				options := clabernetesinternaldirectruntime.ConnectivityOptions{
-					StateDirectory: state,
-					PodNamespace:   "lab",
-					PodName:        "router-pod",
-					PodUID:         "pod-uid-a",
+					StateDirectory:   state,
+					PodNamespace:     "lab",
+					PodName:          "router-pod",
+					PodUID:           "pod-uid-a",
+					FilterOperations: &fakeTransportFilterOperations{},
 				}
 
 				return clabernetesinternaldirectruntime.RunConnectivityWithLifecycleOperations(
@@ -691,6 +692,7 @@ func TestFabricConnectivityRealizesPodLocalEndpointBeforeReadiness(t *testing.T)
 	cancel()
 
 	operations := &fakeLinkOperations{}
+	filter := &fakeTransportFilterOperations{}
 
 	state := t.TempDir()
 	if err := clabernetesinternaldirectruntime.RunConnectivityWithLifecycleOperations(
@@ -698,11 +700,12 @@ func TestFabricConnectivityRealizesPodLocalEndpointBeforeReadiness(t *testing.T)
 		input,
 		plan,
 		clabernetesinternaldirectruntime.ConnectivityOptions{
-			StateDirectory: state,
-			PodNamespace:   "lab",
-			PodName:        "router-pod",
-			PodUID:         "pod-uid-a",
-			PodAddress:     "10.244.0.12",
+			StateDirectory:   state,
+			PodNamespace:     "lab",
+			PodName:          "router-pod",
+			PodUID:           "pod-uid-a",
+			PodAddress:       "10.244.0.12",
+			FilterOperations: filter,
 		},
 		operations,
 		nil,
@@ -712,6 +715,11 @@ func TestFabricConnectivityRealizesPodLocalEndpointBeforeReadiness(t *testing.T)
 
 	if len(operations.fabricSpecs) != 1 {
 		t.Fatalf("fabric operations = %#v", operations.fabricSpecs)
+	}
+
+	if len(filter.specs) == 0 || len(filter.specs[0].UDPPorts) != 1 ||
+		filter.specs[0].UDPPorts[0] != 14790 {
+		t.Fatalf("wire plan must assert the fabric transport accept, got %#v", filter.specs)
 	}
 
 	spec := operations.fabricSpecs[0]
@@ -743,11 +751,12 @@ func TestFabricConnectivityStaysUnreadyUntilPeerResolves(t *testing.T) {
 		input,
 		plan,
 		clabernetesinternaldirectruntime.ConnectivityOptions{
-			StateDirectory: state,
-			PodNamespace:   "lab",
-			PodName:        "router-pod",
-			PodUID:         "pod-uid-a",
-			PodAddress:     "10.244.0.12",
+			StateDirectory:   state,
+			PodNamespace:     "lab",
+			PodName:          "router-pod",
+			PodUID:           "pod-uid-a",
+			PodAddress:       "10.244.0.12",
+			FilterOperations: &fakeTransportFilterOperations{},
 		},
 		&fakeLinkOperations{fabricUnready: true},
 		nil,
@@ -2274,6 +2283,23 @@ func (f *fakeNATOperations) DeleteInterpositionNAT() error {
 	return nil
 }
 
+type fakeTransportFilterOperations struct {
+	specs []clabernetesinternaldirectruntime.TransportFilterSpec
+	err   error
+}
+
+func (f *fakeTransportFilterOperations) EnsureTransportFilterAccepts(
+	spec clabernetesinternaldirectruntime.TransportFilterSpec,
+) error {
+	if f.err != nil {
+		return f.err
+	}
+
+	f.specs = append(f.specs, spec)
+
+	return nil
+}
+
 func interposedConnectivityFixture(
 	t *testing.T,
 ) (clabernetesinternaldeviceplan.Input, clabernetesinternaldeviceplan.Plan) {
@@ -2321,6 +2347,7 @@ func TestInterposedManagementRealizesPodLocallyBeforeReadiness(t *testing.T) {
 
 	operations := &fakeLinkOperations{}
 	nat := &fakeNATOperations{}
+	filter := &fakeTransportFilterOperations{}
 
 	state := t.TempDir()
 	if err := clabernetesinternaldirectruntime.RunConnectivityWithLifecycleOperations(
@@ -2328,14 +2355,20 @@ func TestInterposedManagementRealizesPodLocallyBeforeReadiness(t *testing.T) {
 		input,
 		plan,
 		clabernetesinternaldirectruntime.ConnectivityOptions{
-			StateDirectory: state,
-			PodAddress:     "10.244.0.12",
-			NATOperations:  nat,
+			StateDirectory:   state,
+			PodAddress:       "10.244.0.12",
+			NATOperations:    nat,
+			FilterOperations: filter,
 		},
 		operations,
 		nil,
 	); err != nil {
 		t.Fatal(err)
+	}
+
+	if len(filter.specs) == 0 || len(filter.specs[0].UDPPorts) != 1 ||
+		filter.specs[0].UDPPorts[0] != 14789 {
+		t.Fatalf("mesh plan must assert the mesh transport accept, got %#v", filter.specs)
 	}
 
 	if len(operations.interpositions) != 1 {

--- a/internal/directruntime/interposition.go
+++ b/internal/directruntime/interposition.go
@@ -198,7 +198,9 @@ func interpositionSpecForEntry(
 
 // reconcileInterposition converges the Pod namespace to the plan's interposed management
 // identity. It runs before any device container starts and again on every revision tick so
-// sidecar-owned state displaced by a device is re-asserted. It never mutates device-owned state.
+// sidecar-owned state displaced by a device is re-asserted. It never mutates device-owned state;
+// the one sanctioned write into device-programmed chains is the transport-port accept assertion,
+// which lives in reconcileTransportFilter with its rationale.
 func reconcileInterposition(
 	plan clabernetesinternaldeviceplan.Plan,
 	options ConnectivityOptions,

--- a/internal/directruntime/transportfilter.go
+++ b/internal/directruntime/transportfilter.go
@@ -1,0 +1,75 @@
+package directruntime
+
+import (
+	"errors"
+	"fmt"
+
+	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
+	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
+)
+
+var errTransportFilter = errors.New("transport filter invariant failed")
+
+// TransportFilterSpec lists the UDP destination ports of the sidecar's own transports (the
+// management mesh VTEP and the fabric wire socket) that must stay deliverable across every
+// packet filter programmed in the shared Pod network namespace.
+type TransportFilterSpec struct {
+	// UDPPorts are the transport destination ports to keep accepted; both directions of every
+	// transport address one of these ports, so destination matching covers inbound and outbound.
+	UDPPorts []uint16
+}
+
+// TransportFilterOperations keeps the sidecar's UDP transports exempt from device-programmed
+// packet filters. This is the one sanctioned write into chains the sidecar does not own: a
+// device that filters the shared namespace (EOS installs an INPUT policy drop) severs the
+// transports beneath its own management plane, which no physical wire is subject to -- a
+// control-plane ACL on hardware never sees the wire carrying it. An accept in a sidecar-owned
+// base chain cannot help, because netfilter continues evaluating every other base chain at the
+// hook and any drop there is final, so the accepts must live at the head of the foreign chains
+// themselves. Implementations must be idempotent and must tolerate a device flushing or
+// rebuilding its filter concurrently; the revision tick re-asserts displaced accepts.
+type TransportFilterOperations interface {
+	// EnsureTransportFilterAccepts asserts one accept rule per spec port at the head of every
+	// filter-type input and output base chain the sidecar does not own, across the ip, ip6, and
+	// inet families. Rules already present are left untouched.
+	EnsureTransportFilterAccepts(spec TransportFilterSpec) error
+}
+
+// reconcileTransportFilter derives the active transport ports from the plan and asserts their
+// accepts. It runs beside reconcileInterposition on the cold pass and on every revision tick:
+// wire-only Pods carry no interposed management entry but still depend on the fabric wire port.
+func reconcileTransportFilter(
+	plan clabernetesinternaldeviceplan.Plan,
+	options ConnectivityOptions,
+) error {
+	entry, err := interposedManagementEntry(plan)
+	if err != nil {
+		return err
+	}
+
+	var ports []uint16
+
+	if entry != nil && entry.Interposition != nil && entry.Interposition.Mesh != nil {
+		ports = append(ports, clabernetesconstants.ManagementMeshVXLANPort)
+	}
+
+	if hasRemoteInterfaces(plan) {
+		ports = append(ports, clabernetesconstants.FabricWireServicePort)
+	}
+
+	if len(ports) == 0 {
+		return nil
+	}
+
+	if options.FilterOperations == nil {
+		return fmt.Errorf("%w: transport filter operations are unavailable", errTransportFilter)
+	}
+
+	if err := options.FilterOperations.EnsureTransportFilterAccepts(TransportFilterSpec{
+		UDPPorts: ports,
+	}); err != nil {
+		return fmt.Errorf("ensuring transport filter accepts: %w", err)
+	}
+
+	return nil
+}

--- a/internal/directruntime/transportfilter_linux.go
+++ b/internal/directruntime/transportfilter_linux.go
@@ -1,0 +1,200 @@
+//go:build linux
+
+package directruntime
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/userdata"
+	"golang.org/x/sys/unix"
+)
+
+// transportFilterCommentPrefix marks the sidecar-owned accept rules inside foreign chains; the
+// full comment carries the port ("c9s-transport-14789"). It is written in the iptables-nft
+// comment encoding, so a device round-tripping its ruleset through iptables-save sees a plain
+// `-m comment --comment` rule, and it doubles as the idempotency marker on re-assertion.
+const transportFilterCommentPrefix = "c9s-transport-"
+
+// sidecarTableNamePrefix identifies sidecar-owned tables the sweep must never touch; their
+// chains carry no device policy.
+const sidecarTableNamePrefix = "c9s-"
+
+// transportFilterFamilies returns the families a device filter of the shared namespace can live
+// in. iptables-nft programs ip and ip6; native nft rulesets may use inet. The bridge, arp, and
+// netdev families never carry a local-input filter for UDP transports.
+func transportFilterFamilies() []nftables.TableFamily {
+	return []nftables.TableFamily{
+		nftables.TableFamilyIPv4,
+		nftables.TableFamilyIPv6,
+		nftables.TableFamilyINet,
+	}
+}
+
+type transportFilterOperations struct{}
+
+func newTransportFilterOperations() TransportFilterOperations {
+	return transportFilterOperations{}
+}
+
+// EnsureTransportFilterAccepts sweeps every foreign filter-type input and output base chain and
+// inserts the missing per-port accepts at the chain head. Insertion is unconditional on chain
+// policy: a permissive policy with an explicit drop rule severs the transports just as a drop
+// policy does, and two attributed accept rules are harmless in a chain that would accept anyway.
+func (transportFilterOperations) EnsureTransportFilterAccepts(spec TransportFilterSpec) error {
+	if len(spec.UDPPorts) == 0 {
+		return nil
+	}
+
+	for _, family := range transportFilterFamilies() {
+		if err := ensureFamilyTransportAccepts(family, spec.UDPPorts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ensureFamilyTransportAccepts converges one table family. A kernel built without the family
+// cannot host a device filter in it either, so an unsupported family is success, mirroring the
+// mesh segment clamp's degradation contract.
+func ensureFamilyTransportAccepts(family nftables.TableFamily, ports []uint16) error {
+	conn := &nftables.Conn{}
+
+	chains, err := conn.ListChainsOfTableFamily(family)
+	if err != nil {
+		if isMissingTransportFilterTargetError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("listing family %d filter chains: %w", family, err)
+	}
+
+	for _, chain := range chains {
+		if !isForeignTransportFilterChain(chain) {
+			continue
+		}
+
+		if err := ensureChainTransportAccepts(chain, ports); err != nil {
+			return fmt.Errorf(
+				"asserting transport accepts in %q chain %q: %w",
+				chain.Table.Name,
+				chain.Name,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// isForeignTransportFilterChain selects the chains a device filters local traffic with: filter-
+// type base chains on the input or output hooks, outside the sidecar-owned tables. Non-base
+// chains (a device's jump targets) are only reachable through their base chain and never need
+// their own accept.
+func isForeignTransportFilterChain(chain *nftables.Chain) bool {
+	if chain.Hooknum == nil || chain.Type != nftables.ChainTypeFilter {
+		return false
+	}
+
+	if *chain.Hooknum != *nftables.ChainHookInput && *chain.Hooknum != *nftables.ChainHookOutput {
+		return false
+	}
+
+	if chain.Table == nil || strings.HasPrefix(chain.Table.Name, sidecarTableNamePrefix) {
+		return false
+	}
+
+	return true
+}
+
+// ensureChainTransportAccepts inserts the missing per-port accepts at the head of one chain, in
+// one kernel transaction per chain so a device flushing another table concurrently cannot fail
+// the whole sweep. A chain that disappears between listing and commit is a device rewriting its
+// filter; the next revision tick converges it.
+func ensureChainTransportAccepts(chain *nftables.Chain, ports []uint16) error {
+	conn := &nftables.Conn{}
+
+	rules, err := conn.GetRules(chain.Table, chain)
+	if err != nil {
+		if isMissingTransportFilterTargetError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("listing chain rules: %w", err)
+	}
+
+	present := map[string]bool{}
+
+	for _, rule := range rules {
+		comment, ok := userdata.GetString(rule.UserData, userdata.TypeComment)
+		if ok && strings.HasPrefix(comment, transportFilterCommentPrefix) {
+			present[comment] = true
+		}
+	}
+
+	inserted := false
+
+	for _, port := range ports {
+		comment := transportFilterCommentPrefix + strconv.Itoa(int(port))
+		if present[comment] {
+			continue
+		}
+
+		conn.InsertRule(&nftables.Rule{
+			Table:    chain.Table,
+			Chain:    chain,
+			Exprs:    transportAcceptExpressions(port),
+			UserData: userdata.AppendString(nil, userdata.TypeComment, comment),
+		})
+
+		inserted = true
+	}
+
+	if !inserted {
+		return nil
+	}
+
+	if err := conn.Flush(); err != nil {
+		if isMissingTransportFilterTargetError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("inserting transport accepts: %w", err)
+	}
+
+	return nil
+}
+
+// transportAcceptExpressions is the exact expression sequence iptables-nft generates for
+// `-p udp --dport <port> -j ACCEPT`, so a device's iptables tooling can list, save, and restore
+// the rule as one of its own. Meta L4PROTO carries the parsed transport protocol in every swept
+// family, including ip6 extension chains.
+func transportAcceptExpressions(port uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_UDP}},
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseTransportHeader,
+			Offset:       transportPortOffset,
+			Len:          transportPortLength,
+		},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: portBytes(port)},
+		&expr.Counter{},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	}
+}
+
+// isMissingTransportFilterTargetError classifies the tolerated sweep outcomes: a family the
+// kernel was built without (EAFNOSUPPORT/EOPNOTSUPP) and a chain or table a device removed
+// between listing and commit (ENOENT).
+func isMissingTransportFilterTargetError(err error) bool {
+	return errors.Is(err, unix.ENOENT) ||
+		errors.Is(err, unix.EOPNOTSUPP) ||
+		errors.Is(err, unix.EAFNOSUPPORT)
+}

--- a/internal/directruntime/transportfilter_linux_test.go
+++ b/internal/directruntime/transportfilter_linux_test.go
@@ -1,0 +1,286 @@
+//go:build linux
+
+//nolint:testpackage // dense fixture-driven checks exercise one boundary end to end.
+package directruntime
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/userdata"
+)
+
+const transportFilterNetlinkChild = "C9S_TRANSPORT_FILTER_NETLINK_TEST_CHILD"
+
+func TestTransportFilterAcceptsInIsolatedNamespace(t *testing.T) {
+	if os.Getenv(transportFilterNetlinkChild) == "1" {
+		testTransportFilterAccepts(t)
+
+		return
+	}
+
+	unshare, err := exec.LookPath("unshare")
+	if err != nil {
+		t.Skip("unshare is unavailable")
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unshareArguments := []string{
+		"-Urn",
+		executable,
+		"-test.run=^TestTransportFilterAcceptsInIsolatedNamespace$",
+	}
+	if os.Geteuid() == 0 {
+		unshareArguments[0] = "-n"
+	}
+
+	command := exec.CommandContext( //nolint:gosec // The current test binary is executed in a new namespace.
+		t.Context(),
+		unshare,
+		unshareArguments...,
+	)
+
+	command.Env = append(os.Environ(), transportFilterNetlinkChild+"=1")
+
+	output, err := command.CombinedOutput()
+	if err != nil {
+		if strings.Contains(strings.ToLower(string(output)), "operation not permitted") {
+			t.Skip(
+				"the kernel restricts required netlink operations in an unprivileged user namespace",
+			)
+		}
+
+		t.Fatalf("isolated transport filter test failed: %v\n%s", err, output)
+	}
+}
+
+// deviceShapedFilter builds the ruleset shape iptables-nft leaves behind in a device-managed
+// namespace: a filter table whose INPUT base chain carries a drop policy and a jump to a
+// regular device chain, plus a NAT prerouting chain the sweep must never touch.
+func deviceShapedFilter(t *testing.T, family nftables.TableFamily, tableName string) {
+	t.Helper()
+
+	conn := &nftables.Conn{}
+
+	table := conn.AddTable(&nftables.Table{Family: family, Name: tableName})
+
+	dropPolicy := nftables.ChainPolicyDrop
+
+	input := conn.AddChain(&nftables.Chain{
+		Name:     "INPUT",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookInput,
+		Priority: nftables.ChainPriorityFilter,
+		Policy:   &dropPolicy,
+	})
+
+	device := conn.AddChain(&nftables.Chain{
+		Name:  "EOS_INPUT",
+		Table: table,
+	})
+
+	conn.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: input,
+		Exprs: []expr.Any{
+			&expr.Verdict{Kind: expr.VerdictJump, Chain: device.Name},
+		},
+	})
+
+	if family != nftables.TableFamilyINet {
+		conn.AddChain(&nftables.Chain{
+			Name:     "PREROUTING",
+			Table:    table,
+			Type:     nftables.ChainTypeNAT,
+			Hooknum:  nftables.ChainHookPrerouting,
+			Priority: nftables.ChainPriorityNATDest,
+		})
+	}
+
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("building device-shaped filter for family %d: %v", family, err)
+	}
+}
+
+func chainByName(
+	t *testing.T,
+	family nftables.TableFamily,
+	tableName string,
+	chainName string,
+) *nftables.Chain {
+	t.Helper()
+
+	conn := &nftables.Conn{}
+
+	chains, err := conn.ListChainsOfTableFamily(family)
+	if err != nil {
+		t.Fatalf("listing chains: %v", err)
+	}
+
+	for _, chain := range chains {
+		if chain.Table.Name == tableName && chain.Name == chainName {
+			return chain
+		}
+	}
+
+	return nil
+}
+
+func chainRules(t *testing.T, chain *nftables.Chain) []*nftables.Rule {
+	t.Helper()
+
+	if chain == nil {
+		t.Fatal("chain is absent")
+	}
+
+	conn := &nftables.Conn{}
+
+	rules, err := conn.GetRules(chain.Table, chain)
+	if err != nil {
+		t.Fatalf("listing rules of chain %q: %v", chain.Name, err)
+	}
+
+	return rules
+}
+
+func transportComments(rules []*nftables.Rule) []string {
+	var comments []string
+
+	for _, rule := range rules {
+		comment, ok := userdata.GetString(rule.UserData, userdata.TypeComment)
+		if ok && strings.HasPrefix(comment, transportFilterCommentPrefix) {
+			comments = append(comments, comment)
+		}
+	}
+
+	return comments
+}
+
+func testTransportFilterAccepts(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+
+	deviceShapedFilter(t, nftables.TableFamilyIPv4, "filter")
+	deviceShapedFilter(t, nftables.TableFamilyIPv6, "filter")
+	deviceShapedFilter(t, nftables.TableFamilyINet, "device")
+
+	// The sidecar-owned table with a filter input chain must never be swept.
+	{
+		conn := &nftables.Conn{}
+		owned := conn.AddTable(&nftables.Table{
+			Family: nftables.TableFamilyIPv4,
+			Name:   interpositionTableName,
+		})
+		conn.AddChain(&nftables.Chain{
+			Name:     "input",
+			Table:    owned,
+			Type:     nftables.ChainTypeFilter,
+			Hooknum:  nftables.ChainHookInput,
+			Priority: nftables.ChainPriorityFilter,
+		})
+
+		if err := conn.Flush(); err != nil {
+			t.Fatalf("building sidecar-owned table: %v", err)
+		}
+	}
+
+	operations := newTransportFilterOperations()
+
+	spec := TransportFilterSpec{UDPPorts: []uint16{14789, 14790}}
+
+	if err := operations.EnsureTransportFilterAccepts(spec); err != nil {
+		t.Fatalf("asserting transport accepts: %v", err)
+	}
+
+	// Both accepts sit at the head of every foreign input base chain, before the device jump.
+	for _, target := range []struct {
+		family nftables.TableFamily
+		table  string
+	}{
+		{family: nftables.TableFamilyIPv4, table: "filter"},
+		{family: nftables.TableFamilyIPv6, table: "filter"},
+		{family: nftables.TableFamilyINet, table: "device"},
+	} {
+		rules := chainRules(t, chainByName(t, target.family, target.table, "INPUT"))
+		if len(rules) != 3 {
+			t.Fatalf(
+				"family %d table %q INPUT: expected 2 accepts + 1 device rule, got %d rules",
+				target.family, target.table, len(rules),
+			)
+		}
+
+		head := transportComments(rules[:2])
+		if len(head) != 2 {
+			t.Fatalf(
+				"family %d table %q INPUT: expected the accepts at the chain head, comments %v",
+				target.family, target.table, head,
+			)
+		}
+	}
+
+	// The device jump target, the NAT chain, and the sidecar-owned table stay untouched.
+	if rules := chainRules(
+		t, chainByName(t, nftables.TableFamilyIPv4, "filter", "EOS_INPUT"),
+	); len(rules) != 0 {
+		t.Fatalf("device jump-target chain was mutated: %d rules", len(rules))
+	}
+
+	if rules := chainRules(
+		t, chainByName(t, nftables.TableFamilyIPv4, "filter", "PREROUTING"),
+	); len(rules) != 0 {
+		t.Fatalf("device NAT chain was mutated: %d rules", len(rules))
+	}
+
+	if rules := chainRules(
+		t, chainByName(t, nftables.TableFamilyIPv4, interpositionTableName, "input"),
+	); len(rules) != 0 {
+		t.Fatalf("sidecar-owned chain was swept: %d rules", len(rules))
+	}
+
+	// Re-asserting must not duplicate rules.
+	if err := operations.EnsureTransportFilterAccepts(spec); err != nil {
+		t.Fatalf("re-asserting transport accepts: %v", err)
+	}
+
+	if rules := chainRules(
+		t, chainByName(t, nftables.TableFamilyIPv4, "filter", "INPUT"),
+	); len(rules) != 3 {
+		t.Fatalf("re-assertion is not idempotent: %d rules", len(rules))
+	}
+
+	// A device rewriting its filter flushes the rules; the next assertion converges them back.
+	{
+		conn := &nftables.Conn{}
+		conn.FlushTable(&nftables.Table{Family: nftables.TableFamilyIPv4, Name: "filter"})
+
+		if err := conn.Flush(); err != nil {
+			t.Fatalf("simulating device filter rewrite: %v", err)
+		}
+	}
+
+	if err := operations.EnsureTransportFilterAccepts(spec); err != nil {
+		t.Fatalf("re-asserting after device rewrite: %v", err)
+	}
+
+	rules := chainRules(t, chainByName(t, nftables.TableFamilyIPv4, "filter", "INPUT"))
+	if len(transportComments(rules)) != 2 {
+		t.Fatalf("accepts were not re-asserted after a device rewrite: %d rules", len(rules))
+	}
+
+	// An empty spec is a no-op.
+	if err := operations.EnsureTransportFilterAccepts(TransportFilterSpec{}); err != nil {
+		t.Fatalf("empty spec must be a no-op: %v", err)
+	}
+}

--- a/internal/directruntime/transportfilter_other.go
+++ b/internal/directruntime/transportfilter_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package directruntime
+
+import "fmt"
+
+type unsupportedTransportFilterOperations struct{}
+
+func newTransportFilterOperations() TransportFilterOperations {
+	return unsupportedTransportFilterOperations{}
+}
+
+func (unsupportedTransportFilterOperations) EnsureTransportFilterAccepts(
+	TransportFilterSpec,
+) error {
+	return fmt.Errorf("transport filter assertion requires Linux")
+}

--- a/internal/directruntime/transportfilter_test.go
+++ b/internal/directruntime/transportfilter_test.go
@@ -1,0 +1,154 @@
+//nolint:testpackage // exercises unexported reconcile gating directly.
+package directruntime
+
+import (
+	"testing"
+
+	clabernetesconstants "github.com/clabernetes/clabernetes/constants"
+	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
+)
+
+type recordingTransportFilterOperations struct {
+	specs []TransportFilterSpec
+}
+
+func (r *recordingTransportFilterOperations) EnsureTransportFilterAccepts(
+	spec TransportFilterSpec,
+) error {
+	r.specs = append(r.specs, spec)
+
+	return nil
+}
+
+func meshManagementPlan() clabernetesinternaldeviceplan.ManagementPlan {
+	return clabernetesinternaldeviceplan.ManagementPlan{
+		ID:                "node",
+		InterfaceSelector: clabernetesinternaldeviceplan.ManagementInterfaceInterposed,
+		Interposition: &clabernetesinternaldeviceplan.ManagementInterposition{
+			DeviceInterface: "eth0",
+			Mesh: &clabernetesinternaldeviceplan.ManagementMesh{
+				TunnelID:    100,
+				GatewayMAC:  "02:00:00:00:00:01",
+				PeerService: "c9s-management-mesh",
+			},
+		},
+	}
+}
+
+func wireInterfacePlan() clabernetesinternaldeviceplan.InterfacePlan {
+	return clabernetesinternaldeviceplan.InterfacePlan{
+		ID:           "node-e1-1",
+		Connectivity: clabernetesinternaldeviceplan.ConnectivityWire,
+	}
+}
+
+func TestReconcileTransportFilterDerivesPortsFromPlan(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		plan  clabernetesinternaldeviceplan.Plan
+		ports []uint16
+	}{
+		"no transports": {
+			plan:  clabernetesinternaldeviceplan.Plan{},
+			ports: nil,
+		},
+		"mesh only": {
+			plan: clabernetesinternaldeviceplan.Plan{
+				Management: []clabernetesinternaldeviceplan.ManagementPlan{
+					meshManagementPlan(),
+				},
+			},
+			ports: []uint16{clabernetesconstants.ManagementMeshVXLANPort},
+		},
+		"wires only": {
+			plan: clabernetesinternaldeviceplan.Plan{
+				Interfaces: []clabernetesinternaldeviceplan.InterfacePlan{
+					wireInterfacePlan(),
+				},
+			},
+			ports: []uint16{clabernetesconstants.FabricWireServicePort},
+		},
+		"mesh and wires": {
+			plan: clabernetesinternaldeviceplan.Plan{
+				Management: []clabernetesinternaldeviceplan.ManagementPlan{
+					meshManagementPlan(),
+				},
+				Interfaces: []clabernetesinternaldeviceplan.InterfacePlan{
+					wireInterfacePlan(),
+				},
+			},
+			ports: []uint16{
+				clabernetesconstants.ManagementMeshVXLANPort,
+				clabernetesconstants.FabricWireServicePort,
+			},
+		},
+		"local endpoints carry no wire port": {
+			plan: clabernetesinternaldeviceplan.Plan{
+				Interfaces: []clabernetesinternaldeviceplan.InterfacePlan{
+					{
+						ID:           "node-e1-1",
+						Connectivity: clabernetesinternaldeviceplan.ConnectivitySamePod,
+					},
+				},
+			},
+			ports: nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			operations := &recordingTransportFilterOperations{}
+
+			err := reconcileTransportFilter(tt.plan, ConnectivityOptions{
+				FilterOperations: operations,
+			})
+			if err != nil {
+				t.Fatalf("reconciling transport filter: %v", err)
+			}
+
+			if tt.ports == nil {
+				if len(operations.specs) != 0 {
+					t.Fatalf("expected no filter assertion, got %+v", operations.specs)
+				}
+
+				return
+			}
+
+			if len(operations.specs) != 1 {
+				t.Fatalf("expected exactly one filter assertion, got %+v", operations.specs)
+			}
+
+			got := operations.specs[0].UDPPorts
+			if len(got) != len(tt.ports) {
+				t.Fatalf("expected ports %v, got %v", tt.ports, got)
+			}
+
+			for index, port := range tt.ports {
+				if got[index] != port {
+					t.Fatalf("expected ports %v, got %v", tt.ports, got)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileTransportFilterRequiresOperationsWhenPortsExist(t *testing.T) {
+	t.Parallel()
+
+	plan := clabernetesinternaldeviceplan.Plan{
+		Interfaces: []clabernetesinternaldeviceplan.InterfacePlan{wireInterfacePlan()},
+	}
+
+	if err := reconcileTransportFilter(plan, ConnectivityOptions{}); err == nil {
+		t.Fatal("expected missing filter operations to fail")
+	}
+
+	// A plan without transports must not require the seam at all.
+	if err := reconcileTransportFilter(
+		clabernetesinternaldeviceplan.Plan{},
+		ConnectivityOptions{},
+	); err != nil {
+		t.Fatalf("transport-free plan must not need filter operations: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #320.

## Problem

A device that firewalls the shared Pod network namespace severs the sidecar's transports beneath its own management plane. cEOS installs an iptables `INPUT` policy `DROP` (and, as it turns out, an `OUTPUT` drop and the v6 equivalents too): management-mesh datagrams (UDP 14789) are unsolicited inbound UDP and fall through to the drop, so cross-pod management (ARP, ping, SSH, gNMI to the management address) is dead while the node still reports ready. The per-link wires (UDP 14790) only survive by accident, through the conntrack ESTABLISHED entries their bidirectional keepalives maintain.

## Approach

An accept in a sidecar-owned base chain cannot fix this: netfilter evaluates every base chain registered at a hook and a drop from any of them is final. The accepts have to live at the head of the chains that carry the device's policy. This is therefore the one sanctioned write into chains the sidecar does not own, and it restores hardware semantics rather than bending them: on a physical device the wire carrying management traffic is invisible to a control-plane ACL. The device keeps filtering its own management traffic above the transport.

The new `TransportFilterOperations` seam (wired beside the NAT seam, called on the cold pass and on every revision tick):

- derives the active ports from the plan (mesh membership -> 14789, remote wire endpoints -> 14790; pods with neither are never touched),
- sweeps every foreign filter-type base chain on the input and output hooks across the `ip`, `ip6`, and `inet` families, inserting one accept per port at the chain head; sidecar-owned (`c9s-*`) tables, non-base chains, and non-filter chains are never touched,
- inserts unconditionally rather than only into policy-drop chains, so a permissive policy with an explicit drop rule is covered as well,
- builds each rule from the exact expression sequence iptables-nft generates for `-p udp --dport <port> -j ACCEPT`, with the comment `c9s-transport-<port>` in the iptables-nft userdata encoding, so a device's iptables tooling lists, saves, and restores the rule as one of its own; the comment doubles as the idempotency marker,
- re-asserts displaced accepts on the (default 1s) revision tick after a device rewrites its firewall, and tolerates the expected outcomes: a family the kernel was built without (EAFNOSUPPORT/EOPNOTSUPP, mirroring the mesh segment clamp's degradation contract) and a chain a device removes between listing and commit (ENOENT), with one kernel transaction per chain so a racing rewrite cannot fail the whole sweep.

Known ceiling, documented in the code: kinds using iptables-legacy (x_tables) are out of reach of the nftables API, as are BPF-based drops; no known kind does either.

## Validation

Unit: an unshare-netns test builds an EOS-shaped foreign ruleset (filter INPUT policy drop + jump chain + NAT chain) across all three families and verifies head insertion, idempotency, re-assertion after a simulated rewrite, and that jump targets, NAT chains, and sidecar-owned tables stay untouched. A seam test covers port derivation from the plan. `go test ./internal/directruntime/...`, repo-wide `golangci-lint`, and `make check-docs` pass.

Live (cEOS 4.34.7M + multitool):

- The issue's repro is gone: ARP resolves, ping/SSH/gNMI to the cEOS management address work from peer pods, 0% loss; DF ping measures exactly the realized mesh MTU (1402 passes, 1403 fails on a 1430-byte mesh).
- EOS's OUTPUT drop and v6 drops made the output-hook and ip6 sweeps load-bearing, not speculative.
- `iptables -F INPUT` inside the device: accepts re-asserted in ~1.4s. Applying a control-plane ACL (which EOS programs into its kernel firewall) under a continuous ping: rules stayed in place, 0% loss across the apply.
- Pod restart converges cleanly; `conntrack -F` no longer takes the wires down (they now ride the accept rule, not the ESTABLISHED accident).
- A linux-kind pod with an empty ruleset gets zero rules: the sweep only touches what exists.

Multi-vendor interop (nokia_srlinux 25.10.1 + arista_ceos 4.34.7M + cisco_iol 17.12.01 + juniper_vsrx 23.4R2 + multitool, five cross-kind wires): all nodes ready, management matrix 0% loss in every exercised direction (by address and by DNS name, including from and to the firewalled cEOS), SSH reachable on all four NOS plus gNMI on SRL and cEOS over the mesh, and a configured srl<->ceos data-plane ping over a wire at 0% loss. SRL and IOL program no nftables in the pod namespace and the vSRX vrnetlab wrapper only forward/NAT chains, so the sweep correctly inserts nothing there.

Not covered live: Talos (no cluster available; the family-tolerance path is unit-tested). The readiness gap the issue mentions last (a pod-local probe cannot see this failure class) is deliberately left to a separate issue.
