### PR TITLE
fix: report unreadable image pull Secrets as Node preflight failures

### DIFF
--- a/controllers/node/directstatus.go
+++ b/controllers/node/directstatus.go
@@ -68,6 +68,18 @@ func directPreflightDiagnostic(err error) (reason, message string, report bool) 
 		return "OCIMetadata" + string(metadataErr.Code), metadataErr.Error(), true
 	}
 
+	var pullSecretErr *imagePullSecretError
+	if errors.As(err, &pullSecretErr) {
+		// A referenced pull Secret the resolver cannot read blocks planning exactly like bad
+		// registry credentials do; without a condition the Node would sit with an empty status
+		// while the reconciler retries invisibly.
+		if apimachineryerrors.IsNotFound(pullSecretErr.cause) {
+			return "ImagePullSecretMissing", pullSecretErr.Error(), true
+		}
+
+		return "ImagePullSecretUnreadable", pullSecretErr.Error(), true
+	}
+
 	var applyErr *deploymentApplyError
 	if errors.As(err, &applyErr) {
 		// The API server rejecting the rendered Deployment is terminal until the spec changes;

--- a/controllers/node/directstatus_test.go
+++ b/controllers/node/directstatus_test.go
@@ -103,6 +103,74 @@ func TestReportDirectPreflightFailureStampsDeploymentApplyErrors(t *testing.T) {
 	}
 }
 
+func TestReportDirectPreflightFailureStampsImagePullSecretErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cause      error
+		wantReason string
+	}{
+		{
+			name: "referenced pull secret does not exist",
+			cause: apimachineryerrors.NewNotFound(
+				apimachineryschema.GroupResource{Resource: "secrets"},
+				"regcred",
+			),
+			wantReason: "ImagePullSecretMissing",
+		},
+		{
+			name: "referenced pull secret cannot be read",
+			cause: apimachineryerrors.NewForbidden(
+				apimachineryschema.GroupResource{Resource: "secrets"},
+				"regcred",
+				nil,
+			),
+			wantReason: "ImagePullSecretUnreadable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := nodeReconcileTestScheme(t)
+			node := nodeReconcileTestNode()
+			client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&clabernetesapisv1alpha1.Node{}).WithObjects(node).Build()
+			reconciler := &Reconciler{Client: client, apiReader: client}
+
+			err := reconciler.reportDirectPreflightFailure(
+				context.Background(),
+				node,
+				&imagePullSecretError{namespace: "lab", name: "regcred", cause: test.cause},
+			)
+			if err != nil {
+				t.Fatalf("reportDirectPreflightFailure() error = %v", err)
+			}
+
+			stored := &clabernetesapisv1alpha1.Node{}
+			if err = client.Get(
+				context.Background(),
+				ctrlruntimeclient.ObjectKeyFromObject(node),
+				stored,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			condition := apimachinerymeta.FindStatusCondition(
+				stored.Status.Conditions,
+				clabernetesapisv1alpha1.NodeConditionPlanApplied,
+			)
+			if condition == nil || condition.Status != metav1.ConditionFalse ||
+				condition.Reason != test.wantReason ||
+				!strings.Contains(condition.Message, "lab/regcred") {
+				t.Fatalf("PlanApplied condition = %#v, want reason %q", condition, test.wantReason)
+			}
+		})
+	}
+}
+
 func TestUpdateDirectStatusesUsesCurrentPlanPodAndKubernetesContainerState(t *testing.T) {
 	ctx := context.Background()
 	node := planInputTestNode(

--- a/controllers/node/imagemetadata.go
+++ b/controllers/node/imagemetadata.go
@@ -74,6 +74,22 @@ type OCIMetadataResolver interface {
 	) (*clabernetesinternalocimetadata.Metadata, error)
 }
 
+// imagePullSecretError marks a failure to read a referenced image pull Secret, so the preflight
+// reporter can stamp the Node instead of leaving only a manager log line behind.
+type imagePullSecretError struct {
+	namespace string
+	name      string
+	cause     error
+}
+
+func (e *imagePullSecretError) Error() string {
+	return fmt.Sprintf("resolving image pull Secret %s/%s: %v", e.namespace, e.name, e.cause)
+}
+
+func (e *imagePullSecretError) Unwrap() error {
+	return e.cause
+}
+
 // ImageMetadataResolution contains non-secret planner metadata plus sensitive values used only to
 // prove those bytes never appear in an immutable planner-input ConfigMap.
 type ImageMetadataResolution struct {
@@ -143,7 +159,7 @@ func (r ImageMetadataResolver) Resolve(
 			apimachinerytypes.NamespacedName{Namespace: namespace, Name: name},
 			secret,
 		); err != nil {
-			return nil, fmt.Errorf("resolving image pull Secret %s/%s: %w", namespace, name, err)
+			return nil, &imagePullSecretError{namespace: namespace, name: name, cause: err}
 		}
 		seenSecrets[name] = true
 		secrets = append(secrets, *secret)

--- a/controllers/node/imagemetadata_test.go
+++ b/controllers/node/imagemetadata_test.go
@@ -13,6 +13,7 @@ import (
 	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
 	clabernetesinternalocimetadata "github.com/clabernetes/clabernetes/internal/ocimetadata"
 	k8scorev1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -116,6 +117,47 @@ func TestImageMetadataResolverUsesImportedRolesAndSecretOnlyForRegistryAccess(t 
 		{Number: 22, Protocol: "TCP"}, {Number: 161, Protocol: "UDP"},
 	}) || config.Healthcheck == nil || config.Healthcheck.Interval != int64(5*time.Second) {
 		t.Fatalf("OCI runtime config mapping = %#v", config)
+	}
+}
+
+func TestImageMetadataResolverClassifiesUnreadablePullSecrets(t *testing.T) {
+	t.Parallel()
+
+	scheme := apimachineryruntime.NewScheme()
+	if err := k8scorev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).Build()
+	fake := &fakeOCIMetadataResolver{result: &clabernetesinternalocimetadata.Metadata{}}
+
+	discovery := clabernetesinternaldeviceplan.ImageDiscovery{
+		SchemaVersion: clabernetesinternaldeviceplan.SchemaVersion,
+		Compatibility: planInputTestCompatibility(),
+		InputDigest:   "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Planner: clabernetesinternaldeviceplan.PlannerIdentity{
+			Name:     "clabernetes",
+			Revision: "images-v1",
+		},
+		Images: []clabernetesinternaldeviceplan.ImageRequirement{
+			{NodeID: "node-a", Role: "control", SourceReference: "registry.example/device:1"},
+		},
+	}
+
+	_, err := (ImageMetadataResolver{
+		Client: client, Resolver: fake,
+		Platform: clabernetesinternalocimetadata.Platform{OS: "linux", Architecture: "amd64"},
+	}).Resolve(context.Background(), "lab", discovery, []string{"regcred"})
+
+	var pullSecretErr *imagePullSecretError
+	if !errors.As(err, &pullSecretErr) ||
+		!apimachineryerrors.IsNotFound(pullSecretErr.cause) ||
+		!strings.Contains(err.Error(), "lab/regcred") {
+		t.Fatalf("missing pull Secret error = %v, want classified NotFound", err)
+	}
+
+	if len(fake.requests) != 0 {
+		t.Fatalf("registry contacted despite unresolved pull Secret: %#v", fake.requests)
 	}
 }
 

--- a/docs/guides/image-pull.md
+++ b/docs/guides/image-pull.md
@@ -164,8 +164,10 @@ be addressed by a DNS hostname instead.
 ## Troubleshooting
 
 Metadata authentication or trust failures are reported on the Node before a device workload is
-created. Kubelet pull failures appear on the device Pod as normal events such as `ErrImagePull` or
-`ImagePullBackOff`.
+created. A referenced pull Secret that does not exist or cannot be read is reported the same way:
+`PlanApplied` goes `False` with reason `ImagePullSecretMissing` or `ImagePullSecretUnreadable`
+plus a Warning event, and planning resumes once the Secret is available. Kubelet pull failures
+appear on the device Pod as normal events such as `ErrImagePull` or `ImagePullBackOff`.
 
 Inspect the Node, Pod, events, and resolved profile:
 


### PR DESCRIPTION
Fixes #323.

## Problem

A NodeProfile referencing an image pull Secret that does not exist (or cannot be read) fails direct-mode Node reconciliation before planning, but the failure is invisible: `ImageMetadataResolver.Resolve` returns a plain `fmt.Errorf`, `directPreflightDiagnostic` cannot classify it, and the Node keeps a completely empty `.status` — no condition, no readiness, no event — while the reconciler retries with backoff. The only signal is a repeating manager log line, and deploy tooling waits out its full timeout on `pending nodes: <n> (unknown)`. The image-pull guide promises exactly the opposite: metadata failures are reported on the Node before a device workload is created.

An unresolvable image on the same code path already gets `PlanApplied=False` reason `OCIMetadataResolveManifest` plus a Warning event within seconds; a missing Secret deserved the same visibility. (The default `regcred` stamped by srl-labs/containerlab#3217 that made every public-image lab hit this is fixed separately on that side.)

## Approach

The Secret read failure is now a typed `imagePullSecretError` carrying the namespace, name, and cause, and the preflight diagnostic maps it to `PlanApplied=False` with reason `ImagePullSecretMissing` (NotFound) or `ImagePullSecretUnreadable` (anything else, e.g. RBAC), plus the matching Warning event.

Fail-closed semantics are unchanged: there is no fallback to anonymous access for a Secret that is referenced but unreadable, since planning wants the same credentials the kubelet will use. The failure stays retryable — the reconciler keeps backing off, and planning resumes unaided as soon as the Secret becomes readable.

## Validation

Unit: resolver classification (typed error with the NotFound cause preserved, registry never contacted past an unresolved Secret) and condition stamping for both reasons. `go test ./controllers/node/...`, repo-wide `golangci-lint`, and `make check-docs` pass.

Live (containerlab c9s runtime against a real cluster):

- Deploy referencing a nonexistent Secret: `PlanApplied=False` reason `ImagePullSecretMissing` and the Warning event appear within seconds, the message naming the exact Secret (`resolving image pull Secret <ns>/<name>: secrets "<name>" not found`). With the containerlab-side wait classifying `ImagePullSecret*` like registry failures, the deploy aborts after ~30s with that message instead of hanging until timeout.
- Creating the Secret while the deploy waits: the condition clears, planning resumes without intervention, and the lab converges to ready.
- A lab with no pull Secret reference at all is unaffected and deploys normally.
