### PR TITLE
docs: clarify configuration and tidy guides

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -187,9 +187,10 @@ riding the preserved Pod underlay, with peers discovered through a namespace-sco
 headless Service (`c9s-management-mesh`), so nodes joining or leaving the namespace converge
 on the sidecar's reconcile tick without restarting any Pod. The management *gateway* stays
 strictly Pod-local: every Pod answers the gateway address itself with one deterministic
-identity, and gateway traffic never crosses the mesh. Lab members also resolve each other by
-node name through namespace-local Services; declared `aliases` add extra headless Services
-bound to the same Pod.
+identity, and gateway traffic never crosses the mesh. Inside a device, node names, declared
+`aliases`, and chassis component names resolve to management addresses through a
+namespace-wide peer directory written into each Pod's hosts file; the per-node and alias
+Services serve the rest of the cluster.
 
 A device that firewalls its own network namespace (EOS installs a default-deny input policy)
 cannot sever these transports: the sidecar keeps accept rules for its mesh and wire UDP ports
@@ -234,7 +235,7 @@ if any files would be mounted when using this topology file, and if so renders k
 configmaps containing the file contents and a Topology that appropriately mounts them into
 the pods.
 
-clabverter can also skip the Topology object entirely: `--emit-crs` renders the primitive
+clabverter can also skip the Topology object entirely: `--emitCRs` renders the primitive
 NodeProfile/Link/Node manifests directly, using the same compile and render pipeline as the
 in-cluster compiler (without Topology owner references). This is the preferred path when the
 aggregate source Topology would be too large to persist. Both paths validate identically and

--- a/docs/concepts/containerlab-differences.md
+++ b/docs/concepts/containerlab-differences.md
@@ -87,3 +87,5 @@ diagnostic. Nothing is silently dropped.
 - **The kubelet pulls images.** Pull policy and pull Secrets are Kubernetes-native; there is
   no image import, pull-through, or per-lab insecure-registry setting. c9s reads only registry
   metadata and fails readiness if the running image diverges from the planned digest.
+- **`env-files` and config-engine `config` are rejected.** Environment variables go in `env`,
+  and templated configuration must be rendered before the definition is applied.

--- a/docs/concepts/containerlab-differences.md
+++ b/docs/concepts/containerlab-differences.md
@@ -51,9 +51,9 @@ diagnostic. Nothing is silently dropped.
   node name it cannot carry is sanitized: the name is lower-cased, every other character becomes
   `-`, a name starting with a digit is prefixed with `clab-`, and a name longer than 63
   characters is truncated and suffixed with a hash. `R1` becomes `r1`, `PE_1` becomes `pe-1`.
-  Every reference follows the node -- links, `network-mode: container:<node>`, and the node-keyed
+  Every reference follows the node: links, `network-mode: container:<node>`, and the node-keyed
   policy on the Topology (`filesFromConfigMap`, `filesFromSecret`, `filesFromURL`, `resources`,
-  `statusProbes`) is still written with the name the definition uses. Two node names that differ
+  `statusProbes`) are still written with the name the definition uses. Two node names that differ
   only in something Kubernetes cannot carry (`R1` and `r1`) would become one object, and that
   fails compilation. The namespace is the topology boundary.
 - **`labels` become Kubernetes labels** on the emitted Node, its Deployment, and Pods

--- a/docs/concepts/nodes-and-links.md
+++ b/docs/concepts/nodes-and-links.md
@@ -31,6 +31,31 @@ A Node can reference one same-namespace
 [NodeProfile](/docs/concepts/node-profiles). If the reference is omitted, global `Config`
 defaults apply. An explicit reference that does not exist prevents the Node from being realized.
 
+### Node fields
+
+The Node spec accepts the portable containerlab node vocabulary. Unknown fields are rejected
+when the manifest is applied, and known fields without a Pod mapping fail planning with a
+diagnostic naming the field.
+
+- **Realized as declared:** `kind`, `type`, `image`, `image-pull-policy`, `entrypoint`, `cmd`,
+  `env`, `user`, `sysctls`, `devices`, `cap-add`, `privileged`, `security-opts`, `tmpfs`,
+  `shm-size`, `cpu`, `memory`, `dns`, `healthcheck`, `startup-delay`, `restart-policy`
+  (`always` or `unless-stopped`), `exec`, `mgmt-ipv4`, `mgmt-ipv6`, `ports`, `aliases`,
+  `group`, `extras`, `components`, and `certificate`.
+- **Files:** `startup-config` (inline text or a path), `license`, and `binds` take their content
+  from payloads attached to the Node, see
+  [Containerlab file fields](/docs/guides/file-mounting#containerlab-file-fields).
+- **Grouping:** `network-mode: container:<primary>` places the Node in the primary Node's Pod.
+  Other network modes are rejected.
+- **Link changes:** `link-apply-mode` (`live`, `restart`, or `recreate`) overrides the kind's
+  default action when Links of the Node change.
+- **Rejected at planning:** `config` (config-engine variables), `env-files`, `runtime`,
+  `stages`, and `credentials`, see
+  [Differences from containerlab](/docs/concepts/containerlab-differences).
+
+Inside a device, node names, aliases, and chassis component names resolve to management
+addresses, see [Management network](/docs/guides/management-network#name-resolution).
+
 ## Link
 
 A Link declares exactly two endpoints: one wire, nothing else.
@@ -59,7 +84,7 @@ allocated wire id.
 
 Each Node grows only with its own configuration and each Link remains one wire. This removes the
 single aggregate-object size limit of a source Topology and allows tooling such as `clabverter
---emit-crs` to produce independently reconciled resources.
+--emitCRs` to produce independently reconciled resources.
 
 Direct resources do not promise unlimited scale: Kubernetes API capacity, controller throughput,
 and the total object count still matter.
@@ -71,4 +96,5 @@ The
 contains a NodeProfile, two Nodes, and one Link.
 
 See the [Node reference](/docs/crd/node) and
-[Link reference](/docs/crd/link) for all fields.
+[Link reference](/docs/crd/link) for all fields, and [Operating a lab](/docs/guides/lab-operations)
+for reading Node and Link status.

--- a/docs/concepts/topology.md
+++ b/docs/concepts/topology.md
@@ -88,6 +88,11 @@ The compiler:
 4. prunes generated resources removed from the source
 5. aggregates bounded readiness and resource counts into Topology status
 
+`status.observedGeneration` records the Topology generation whose compiled resources were last
+applied, so the reported readiness refers to the current definition only once it equals
+`metadata.generation`. `status.topologyState` is `deploying`, `running`, `degraded`, or
+`deployfailed`.
+
 ## Child-resource name conflicts
 
 Generated Node, Link, and NodeProfile names are namespace-scoped and are not automatically
@@ -109,7 +114,7 @@ A Topology still embeds the entire source lab in one Kubernetes object. For larg
 prefer direct resources or use:
 
 ```bash
-clabverter --emit-crs <topology-file>
+clabverter --emitCRs <topology-file>
 ```
 
 This emits NodeProfile, Node, and Link manifests without persisting an aggregate Topology.

--- a/docs/crd/config.mdx
+++ b/docs/crd/config.mdx
@@ -4,7 +4,11 @@ description: Config custom resource schema.
 icon: SlidersHorizontal
 ---
 
-The `Config` CRD holds cluster-wide defaults applied when Nodes do not reference an explicit
-NodeProfile.
+The `Config` CRD holds the cluster-wide defaults for direct device Pods: pull policy and pull
+Secrets, default resources, node selectors by image, and the controller-only registry metadata
+trust and mirror policies. A NodeProfile referenced by a Node overrides only the fields it sets;
+everything else comes from the Config. One Config named `clabernetes` lives in the namespace
+where c9s is installed. See [Global configuration](/docs/installation#global-configuration) for
+how it is created and edited.
 
 <CrdViewer name="config" />

--- a/docs/guides/clabverter.md
+++ b/docs/guides/clabverter.md
@@ -1,0 +1,58 @@
+---
+title: Converting containerlab topologies
+description: Use clabverter to turn a containerlab topology and the files it references into c9s manifests.
+---
+
+clabverter converts a containerlab topology file, together with the local files it references,
+into Kubernetes manifests. Files become ConfigMaps, and each node receives them through
+`filesFromConfigMap` at the path the definition names, so the topology needs no changes.
+
+## Get clabverter
+
+Download the binary for your platform from the
+[release assets](https://github.com/clabernetes/clabernetes/releases), or run the container
+image from the directory that holds the topology:
+
+```bash
+docker run --rm -v "$(pwd)":/clabernetes/work \
+  ghcr.io/clabernetes/clabernetes/clabverter:latest --stdout
+```
+
+## Convert
+
+```bash
+clabverter --topologyFile lab.clab.yml --destinationNamespace lab --outputDirectory ./manifests
+kubectl apply -f ./manifests
+```
+
+Without `--topologyFile`, clabverter uses the `*.clab.yml` or `*.clab.yaml` file in the current
+directory. The
+output includes a Namespace manifest, one ConfigMap per startup configuration, one ConfigMap per
+mounted file, and the Topology.
+
+| Flag | Effect |
+| --- | --- |
+| `--emitCRs` | emit NodeProfile, Node, and Link manifests instead of a Topology, exactly what the in-cluster compiler would produce, for labs too large for one Topology object |
+| `--imagePullSecrets regcred` | set `imagePull.pullSecrets` (comma-separated) |
+| `--disableExpose` | set `exposeType: None` |
+| `--topoSpecFile values.yaml` | merge additional Topology spec fields, such as `deployment` or `expose`, from a file |
+| `--stdout` | print the manifests instead of writing files |
+
+## What is converted
+
+- `startup-config` file references are read from disk. Inline configuration (a value with
+  newlines) is written to a ConfigMap and mounted at `/clabernetes/startup-config.partial.cfg`,
+  with the definition rewritten to that path.
+- `license` files and `binds` sources become ConfigMaps mounted at the same path the definition
+  names. Bind targets that the Pod owns, such as `/etc/hosts`, are rejected.
+- Node names Kubernetes cannot carry are sanitized, see
+  [Differences from containerlab](/docs/concepts/containerlab-differences#naming-and-metadata).
+
+Conversion fails with the same diagnostics as the in-cluster compiler when the definition uses
+fields c9s cannot realize. Files larger than the ConfigMap limit must be delivered as
+[URL payloads](/docs/guides/file-mounting#mounting-files-from-urls) instead.
+
+## Related
+
+- [Topology](/docs/concepts/topology)
+- [File mounting](/docs/guides/file-mounting)

--- a/docs/guides/expose-configuration.md
+++ b/docs/guides/expose-configuration.md
@@ -42,6 +42,11 @@ and targets that same port on the device Pod directly, with no Docker port publi
 between. This is why `ports` entries declare a destination port only. Declared `aliases`
 each add an extra headless Service selecting the node's Pod under the alias name.
 
+Nodes that share one Pod through `network-mode: container:<primary>` share one port space. A
+port an image exposes is kept for the first member that brings it, an explicit `ports` entry
+takes precedence over an image-exposed port, and two members declaring the same explicit port
+fail planning.
+
 ### Portable containerlab topologies
 
 A normal containerlab `ports` entry publishes the port on the local Docker host. When a port is
@@ -59,7 +64,7 @@ topology:
 
 The value is a comma-separated list using the same destination-port grammar as `Node.spec.ports`.
 Each entry is a destination port with an optional `tcp` or `udp` protocol. The c9s topology
-compiler and `clabverter --emit-crs` consume all entries into `Node.spec.ports`; the label is not
+compiler and `clabverter --emitCRs` consume all entries into `Node.spec.ports`; the label is not
 copied to Kubernetes labels. Invalid entries fail compilation. Local containerlab keeps the value
 as an inert container label and does not publish either port on the host.
 

--- a/docs/guides/expose-configuration.md
+++ b/docs/guides/expose-configuration.md
@@ -18,32 +18,9 @@ declared network aliases.
 The default `LoadBalancer` mode is built into c9s. The global `Config` resource does not configure
 an exposure mode.
 
-> **Upgrade notice:** `disableExpose` has been removed from the Topology and NodeProfile APIs.
-> Before upgrading the CRDs or controller, replace every `disableExpose: true` with
-> `exposeType: None`. Otherwise the removed setting cannot suppress the built-in LoadBalancer
-> default. The new structural schemas reject manifests that still contain `disableExpose`.
-
-Inspect live exposure policy before upgrading:
-
-```bash
-kubectl get topologies,nodeprofiles -A -o yaml
-```
-
-Update the declarative source and apply it with the old controller still running:
-
-```yaml
-# Before
-spec:
-  expose:
-    disableExpose: true
-```
-
-```yaml
-# After
-spec:
-  expose:
-    exposeType: None
-```
+> **Upgrade notice:** `disableExpose` was removed from the Topology and NodeProfile APIs.
+> Replace every `disableExpose: true` with `exposeType: None` before applying manifests to this
+> release; manifests that still contain `disableExpose` are rejected.
 
 ## How exposure works
 
@@ -260,14 +237,7 @@ spec:
 - Creates a headless service (`clusterIP: None`)
 - DNS queries return pod IPs directly instead of a virtual service IP
 - No load balancing or proxying by kube-proxy
-- Useful for StatefulSet-like access patterns where you need direct pod connectivity
-
-**Use cases:**
-
-- Service discovery where clients need to connect directly to specific pods
-- Custom load balancing logic in client applications
-- Integration with external service meshes that handle their own load balancing
-- Scenarios where you need DNS-based pod discovery without Kubernetes proxying
+- Useful when a client must reach the Pod address directly
 
 ### None
 
@@ -391,20 +361,6 @@ ssh admin@srl1.default.svc.cluster.local
 # the node, and unqualified exec targets the device application container
 kubectl exec -it deploy/srl1 -- sr_cli
 ```
-
-## Best Practices
-
-1. **Production deployments**: Use `exposeType: LoadBalancer` with `disableAutoExpose: true` to expose only necessary ports
-
-2. **CI/CD pipelines**: Use `exposeType: None` when nodes only need fabric connectivity
-
-3. **Development**: Use default settings for convenience
-
-4. **Security**: Disable auto-expose and explicitly define only required ports
-
-5. **Cost optimization**: Use `ClusterIP` or `Headless` when external access isn't needed
-
-6. **Service mesh integration**: Use `exposeType: Headless` when integrating with service meshes that handle their own load balancing
 
 ## Related
 

--- a/docs/guides/file-mounting.md
+++ b/docs/guides/file-mounting.md
@@ -230,6 +230,28 @@ URL payloads are fetched anonymously. For content behind authentication, load it
 ConfigMap or Secret and reference that instead. Registry credentials belong in Kubernetes
 `imagePull.pullSecrets`, not in file mounting.
 
+## Containerlab file fields
+
+Containerlab node fields that name a file on the local host are satisfied by payloads instead.
+A path in the definition that equals the `filePath` of a `filesFromConfigMap`,
+`filesFromSecret`, or `filesFromURL` entry of the same Node is served from that payload:
+
+- `startup-config` inline text (a value containing newlines) is embedded in the plan and needs
+  no payload. A `startup-config` path must match a payload `filePath`.
+- `license` works the same way: mount the license at the path the field names, as in the
+  [Nokia SR-SIM guide](/docs/guides/nokia-srsim#license-file-mounting).
+- `binds` entries (`source:target` with an optional `ro`) mount a payload into the device at
+  `target`. The source must be a payload `filePath` of that Node, or a directory that contains
+  one. Anything else is rejected because there is no host to bind from.
+- `env-files` are rejected. Put the variables in `env`.
+
+Destination paths the Pod owns are rejected before anything is created: `/etc/hosts`,
+`/etc/hostname`, `/etc/resolv.conf`, `/dev/termination-log`, and everything under
+`/var/lib/clabernetes` and `/var/run/clabernetes`.
+
+[clabverter](/docs/guides/clabverter) produces these payloads automatically from a containerlab
+topology directory.
+
 ## Common Use Cases
 
 ### License Files

--- a/docs/guides/file-mounting.md
+++ b/docs/guides/file-mounting.md
@@ -416,11 +416,7 @@ Ensure correct mode:
 
 ### ConfigMap Size Limit
 
-If exceeding 1MB:
-
-- Use URL-based mounting
-- Split into multiple ConfigMaps
-- Compress content
+If a file exceeds 1MB, mount it from a URL instead or split it into multiple ConfigMaps.
 
 ### URL Download Failures
 
@@ -437,14 +433,6 @@ Verify URL accessibility:
 ```bash
 kubectl run curl-test --rm -it --image=curlimages/curl -- curl -I <url>
 ```
-
-## Best Practices
-
-1. **Use Secrets for sensitive data**: Licenses, credentials, certificates
-2. **Use URLs for large files**: Configurations beyond the ConfigMap limit (up to 64 MB)
-3. **Version your ConfigMaps**: Include version in name for traceability
-4. **Use descriptive paths**: Match vendor conventions for file locations
-5. **Test file accessibility**: Verify URLs work before deploying
 
 ## Related
 

--- a/docs/guides/image-pull.mdx
+++ b/docs/guides/image-pull.mdx
@@ -1,16 +1,16 @@
 ---
 title: Image pulling
-description: Configure direct kubelet pulls, private registry credentials, registry trust, and controller metadata mirrors.
+description: Configure pull policy, private registry credentials, registry trust, and controller metadata mirrors.
 ---
 
-Device images run directly in c9s-managed Pods. The kubelet and cluster container runtime are the
-only components that download and start them. c9s does not import image layers, create image-puller
-Pods, mount a CRI socket, or copy images into an inner Docker daemon.
+The kubelet pulls device images like the image of any other Pod. c9s has no inner Docker daemon,
+image-puller Pods, or image import path, so registry access is configured the Kubernetes way:
+pull policy and pull Secrets on the workload, mirrors and trust in the worker container runtime.
 
 ## Pull policy
 
-Set the default Kubernetes pull policy in the singleton Config or in the one NodeProfile
-selected by a Node:
+The default pull policy is `IfNotPresent`. Change it in the singleton Config, in a NodeProfile,
+or in a Topology's `spec.imagePull`:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -19,16 +19,16 @@ metadata:
   name: clabernetes
 spec:
   imagePull:
-    policy: IfNotPresent
+    policy: Always
 ```
 
-The supported values are the Kubernetes policies `Always`, `IfNotPresent`, and `Never`. An
-explicit image-pull policy produced by the imported containerlab node definition takes precedence
-over this profile default.
+The supported values are `Always`, `IfNotPresent`, and `Never`. A node that sets
+`image-pull-policy` in its containerlab definition keeps that value.
 
 ## Private registry credentials
 
-Create a Docker registry Secret in the same namespace as the target Node or Topology. In the example below, the Secret named `regcred` is created in the `lab` namespace for a private registry at `registry.example.com` with username `myuser` and password `mypass`:
+Create a Docker registry Secret in the namespace where the Node or Topology lives. The example
+creates a Secret named `regcred` in the `lab` namespace for the registry `registry.example.com`:
 
 ```bash
 kubectl -n lab create secret docker-registry regcred \
@@ -37,13 +37,12 @@ kubectl -n lab create secret docker-registry regcred \
   --docker-password=mypass
 ```
 
-The created registry credentials Secret can be configured as a global default or referenced in a
-NodeProfile or Topology to allow the kubelet to pull images from the private registry.
+Then set the Secret name as a global default in the Config, or reference it from a NodeProfile
+or Topology:
 
 <Tabs items={['Config', 'NodeProfile', 'Topology']}>
 <Tab>
-Set a global default in the singleton Config when every workload namespace should use the same
-pull Secret name:
+The Config default applies to every Node in the cluster:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -56,12 +55,20 @@ spec:
       - regcred
 ```
 
-Nodes inherit this list unless their NodeProfile overrides it. An explicitly empty NodeProfile
-list clears the global default. Because Secrets are namespaced, each listed Secret must exist in
-every workload namespace that inherits the default.
+Secrets are namespaced, so the Secret must exist in every namespace that runs Nodes. A Node in
+a namespace without it is not planned: its `PlanApplied` condition reports
+`ImagePullSecretMissing` until the Secret appears. See
+[centrally managed credentials](#centrally-managed-credentials) for mirroring one Secret into
+many namespaces.
+
+A NodeProfile that sets `pullSecrets` replaces the global list for its Nodes, and
+`pullSecrets: []` opts them out of the global default.
+
+With Helm, set the same default through `globalConfig.imagePull.pullSecrets` in the chart
+values.
 </Tab>
 <Tab>
-Here is an example of a NodeProfile that uses the `regcred` Secret for image pulling:
+A NodeProfile applies the Secret to every Node that references it:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -87,6 +94,8 @@ spec:
 ```
 </Tab>
 <Tab>
+A Topology applies the Secret to all of its nodes. The Topology controller copies
+`spec.imagePull` into the NodeProfile it generates:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -118,47 +127,47 @@ spec:
 </Tab>
 </Tabs>
 
-c9s places the Secret name in `Pod.spec.imagePullSecrets`; credential bytes are never stored in a
-device plan or immutable ConfigMap. The controller accepts only Kubernetes Docker-config Secret
-types when it needs the same credentials for OCI metadata access.
-
-Topology-level `spec.imagePull` is compiled into the shared NodeProfile generated for that
-Topology. Direct Node manifests select a profile explicitly through
-`Node.spec.profileRef`.
+c9s passes only the Secret name to the kubelet through `Pod.spec.imagePullSecrets`. The
+controller also reads the Secret to fetch the image manifest before it creates the Pod, so the
+Secret must be of type `kubernetes.io/dockerconfigjson` or `kubernetes.io/dockercfg`, which
+`kubectl create secret docker-registry` produces. Credential bytes are never copied into a plan
+or ConfigMap.
 
 ### Centrally managed credentials
 
-If you want to create the Secret in a single namespace and have it mirrored to all or some namespaces, you can use a tool like [External Secrets Operator](https://external-secrets.io) or [kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector) to automatically copy the Secret to the namespaces where your device Pods will run. This way, you can manage your registry credentials in one place and ensure that all relevant namespaces have access to them.
+To manage registry credentials in one place, create the Secret once and mirror it into the lab
+namespaces with a tool such as [External Secrets Operator](https://external-secrets.io) or
+[kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector). Together with the
+Config default, a new lab namespace then needs no registry setup at all.
 
-With kubernetes-reflector, you can install it in your cluster in the `c9s` namespace where c9s operator runs as follows:
+With kubernetes-reflector, install it next to c9s:
 
-```
+```bash
 helm upgrade --namespace c9s --install reflector oci://ghcr.io/emberstack/helm-charts/reflector
 ```
 
-Then create the `regcred` Secret in the `c9s` namespace and configure the reflector to mirror it to all or some namespaces.
+Create the `regcred` Secret in the `c9s` namespace and annotate it so the reflector mirrors it
+into every namespace:
 
-```bash title="annotating the regcred Secret to mirror it to all namespaces"
+```bash
 kubectl -n c9s annotate secret regcred \
   reflector.v1.k8s.emberstack.com/reflection-allowed=true \
   reflector.v1.k8s.emberstack.com/reflection-auto-enabled=true
-
 ```
+
+To mirror into selected namespaces only, add the
+`reflector.v1.k8s.emberstack.com/reflection-auto-namespaces` annotation with a comma-separated
+list of namespaces.
 
 ## Registry mirrors, private CAs, HTTP, and proxies
 
-Configure registry mirrors, runtime proxy settings, private certificate authorities, and
-plain-HTTP endpoints in the container runtime on every Kubernetes node eligible to run a device
-Pod. The files and reload procedure depend on the cluster distribution and runtime. Validate that
-path by scheduling an ordinary Pod with the same image, placement, pull policy, and pull Secret.
-Node-runtime mirrors do not configure controller metadata access; when the controller must reach
-registries through the same mirrors, declare them as
-[controller metadata mirrors](#controller-metadata-mirrors) as well.
+Registry mirrors, proxies, private certificate authorities, and plain-HTTP registries are
+configured in the container runtime of every worker that can run a device Pod, not in c9s. The
+files and reload steps depend on the Kubernetes distribution and runtime.
 
-Before creating the device Pod, the c9s controller fetches only the OCI manifest and configuration
-blob required by package-driven planning. Publicly trusted HTTPS needs no extra setting. If this
-metadata request needs a private CA or an explicitly permitted HTTP endpoint, configure an exact
-registry authority in the Config:
+Before it creates a device Pod, the c9s controller fetches the image manifest and configuration
+from the registry (never the layers) to plan the Pod. Public HTTPS registries need no extra
+setting. If the registry uses a private CA or plain HTTP, add a trust entry for it in the Config:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -177,19 +186,19 @@ spec:
         plainHTTP: true
 ```
 
-This trust policy affects only controller metadata access. It does not configure kubelets,
-mirrors, proxies, or node trust. Entries match exact `host[:port]` authorities. Wildcards, schemes,
-repository paths, duplicate authorities, empty exceptions, and a CA combined with `plainHTTP` are
-rejected. Configure the equivalent trust and endpoint in the node runtime as well. Prefer TLS with
-a private CA; plain HTTP has no transport encryption.
+Entries match the exact `host[:port]` of the registry. Wildcards and paths are not accepted, and
+an entry sets either `caBundle` or `plainHTTP`. This trust applies only to the controller's
+metadata requests: configure the same CA or HTTP endpoint in the worker runtime as well, and
+prefer TLS with a private CA over plain HTTP. If the workers pull through a mirror, also declare
+it as a [controller metadata mirror](#controller-metadata-mirrors).
 
 ## Controller metadata mirrors
 
-Some clusters pull every image through a CRI-level pull-through registry, for example Harbor proxy
-projects configured through containerd `hosts.toml` or Talos `machine.registries.mirrors`. The
-kubelet then pulls public references such as `ghcr.io/...` without reaching the public registry,
-but the controller's metadata request would still dial the original registry host. Declare the
-same mirrors for controller metadata access in the Config:
+Some clusters pull every image through a pull-through registry configured in the container
+runtime, for example Harbor proxy projects set up through containerd `hosts.toml` or Talos
+`machine.registries.mirrors`. The kubelet then never reaches the public registry, but the
+controller's metadata request would still dial it. Declare the same mirrors for the controller
+in the Config:
 
 ```yaml
 apiVersion: c9s.run/v1alpha1
@@ -213,36 +222,35 @@ spec:
           -----END CERTIFICATE-----
 ```
 
-Each entry redirects the controller's manifest and config requests for one exact source registry
-to the mirror endpoint. Docker Hub aliases (`docker.io`, `index.docker.io`,
-`registry-1.docker.io`) share one entry. Only the HTTP connection is rewritten: image references,
-resolved digest identities, and Pod image strings keep the original registry, so kubelets keep
-using their own runtime mirror configuration. There is no origin fallback; a failing mirror fails
-planning with a Node condition instead of silently retrying the public registry.
+Each entry redirects the controller's manifest and configuration requests for one source
+registry to the mirror endpoint. The Docker Hub names `docker.io`, `index.docker.io`, and
+`registry-1.docker.io` share one entry. Only the connection changes: image references, resolved
+digests, and Pod image strings keep the original registry, so kubelets keep using their own
+mirror configuration. A failing mirror fails planning with a Node condition; there is no
+fallback to the public registry.
 
-`overridePath` treats the endpoint path as the mirror's registry API root, replacing the standard
-`/v2` prefix (containerd `override_path` semantics). A Harbor proxy project for `ghcr.io` at
-`https://harbor.example.com/v2/ghcr` serves `ghcr.io/srl-labs/network-multitool` at
+`overridePath` treats the endpoint path as the mirror's registry API root, replacing the
+standard `/v2` prefix (containerd `override_path` semantics). A Harbor proxy project for
+`ghcr.io` at `https://harbor.example.com/v2/ghcr` serves `ghcr.io/srl-labs/network-multitool` at
 `/v2/ghcr/srl-labs/network-multitool/...`. An endpoint with a path requires `overridePath`; a
 hostname-only endpoint such as `https://mirror.example.com` forwards paths unchanged.
 
-Transport trust follows the connection: a `registryMetadataTrust` entry for the mirror endpoint
-host applies to every source registry fetched through that mirror. The endpoint scheme selects
-TLS or plain HTTP, and the mirror answers its own authentication challenges. Pull Secret
-credentials still match the source registry in the image reference.
+Trust follows the connection: a `registryMetadataTrust` entry for the mirror host applies to
+every registry fetched through that mirror, and the endpoint scheme selects TLS or plain HTTP.
+Pull Secret credentials still match the source registry in the image reference.
 
-One sharp edge: the metadata client refuses authentication-token realms that are loopback or
-RFC 1918 IP literals (a server-side request forgery guard). Harbor advertises its configured
-external URL as the token realm, so a Harbor mirror reachable only as a private IP literal must
-be addressed by a DNS hostname instead.
+The authentication token realm a mirror advertises must be a DNS hostname: the controller
+refuses realms that point at loopback or private IP addresses. Harbor advertises its configured
+external URL as the realm, so a Harbor mirror that is reachable only by a private IP must be
+given a hostname.
 
 ## Troubleshooting
 
-Metadata authentication or trust failures are reported on the Node before a device workload is
-created. A referenced pull Secret that does not exist or cannot be read is reported the same way:
-`PlanApplied` goes `False` with reason `ImagePullSecretMissing` or `ImagePullSecretUnreadable`
-plus a Warning event, and planning resumes once the Secret is available. Kubelet pull failures
-appear on the device Pod as normal events such as `ErrImagePull` or `ImagePullBackOff`.
+Problems the controller finds before it creates the Pod are reported on the Node: `PlanApplied`
+becomes `False` with a reason such as `ImagePullSecretMissing`, `ImagePullSecretUnreadable`, or
+an `OCIMetadata...` reason for registry authentication and trust failures, plus a Warning
+event. Planning resumes on its own once the cause is fixed. Pull failures on the worker appear
+on the device Pod as the usual `ErrImagePull` or `ImagePullBackOff` events.
 
 Inspect the Node, Pod, events, and resolved profile:
 
@@ -253,7 +261,7 @@ kubectl -n lab describe pod -l c9s.run/direct-workload=router
 kubectl -n lab get nodeprofile private-images -o yaml
 ```
 
-Test the kubelet path independently:
+Test the kubelet path independently with a plain Pod that uses the same image and pull Secret:
 
 ```bash
 kubectl -n lab run image-pull-test --restart=Never --image=registry.example.com/network/srlinux:latest \
@@ -261,8 +269,8 @@ kubectl -n lab run image-pull-test --restart=Never --image=registry.example.com/
 kubectl -n lab describe pod image-pull-test
 ```
 
-If the test Pod fails, fix the Secret or cluster-runtime registry configuration. c9s deliberately
-has no CRI-socket, insecure-registry, pull-through, Docker-config mount, or image-import fallback.
+If the test Pod fails, fix the Secret or the worker's registry configuration. c9s has no
+insecure-registry, pull-through, or image-import fallback of its own.
 
 ## Related
 

--- a/docs/guides/image-pull.mdx
+++ b/docs/guides/image-pull.mdx
@@ -28,7 +28,7 @@ over this profile default.
 
 ## Private registry credentials
 
-Create a Docker registry Secret in the same namespace as the target Node or Topology. In the example below, the Secret is named `regcred` is created in the `lab` namespace for a private registry at `registry.example.com` with username `myuser` and password `mypass`:
+Create a Docker registry Secret in the same namespace as the target Node or Topology. In the example below, the Secret named `regcred` is created in the `lab` namespace for a private registry at `registry.example.com` with username `myuser` and password `mypass`:
 
 ```bash
 kubectl -n lab create secret docker-registry regcred \
@@ -37,9 +37,29 @@ kubectl -n lab create secret docker-registry regcred \
   --docker-password=mypass
 ```
 
-The created registry credentials Secret can be referenced in a NodeProfile or Topology to allow the kubelet to pull images from the private registry.
+The created registry credentials Secret can be configured as a global default or referenced in a
+NodeProfile or Topology to allow the kubelet to pull images from the private registry.
 
-<Tabs items={['NodeProfile', 'Topology']}>
+<Tabs items={['Config', 'NodeProfile', 'Topology']}>
+<Tab>
+Set a global default in the singleton Config when every workload namespace should use the same
+pull Secret name:
+
+```yaml
+apiVersion: c9s.run/v1alpha1
+kind: Config
+metadata:
+  name: clabernetes
+spec:
+  imagePull:
+    pullSecrets:
+      - regcred
+```
+
+Nodes inherit this list unless their NodeProfile overrides it. An explicitly empty NodeProfile
+list clears the global default. Because Secrets are namespaced, each listed Secret must exist in
+every workload namespace that inherits the default.
+</Tab>
 <Tab>
 Here is an example of a NodeProfile that uses the `regcred` Secret for image pulling:
 
@@ -116,9 +136,9 @@ With kubernetes-reflector, you can install it in your cluster in the `c9s` names
 helm upgrade --namespace c9s --install reflector oci://ghcr.io/emberstack/helm-charts/reflector
 ```
 
-Then create the `regred` Secret in the `c9s` namespace and configure the reflector to mirror it to all or some namespaces.
+Then create the `regcred` Secret in the `c9s` namespace and configure the reflector to mirror it to all or some namespaces.
 
-```bash title="annotating the regred Secret to mirror it to all namespaces"
+```bash title="annotating the regcred Secret to mirror it to all namespaces"
 kubectl -n c9s annotate secret regcred \
   reflector.v1.k8s.emberstack.com/reflection-allowed=true \
   reflector.v1.k8s.emberstack.com/reflection-auto-enabled=true

--- a/docs/guides/lab-operations.md
+++ b/docs/guides/lab-operations.md
@@ -1,0 +1,136 @@
+---
+title: Operating a lab
+description: What c9s creates in a namespace, how to read Node, Link, and Topology status, and how to reach logs and packets.
+---
+
+This guide covers the day-to-day view of a running lab: the objects c9s creates, how to read
+their status, and how to get at logs and packets.
+
+## What c9s creates in a namespace
+
+For every Node:
+
+- a Deployment and Pod named after the Node; grouped Nodes (`network-mode: container:<primary>`)
+  share the primary's Pod
+- the expose Service named after the Node, a headless `<node>-wire` Service for wire peer
+  discovery, and one headless Service per declared alias
+- immutable plan ConfigMaps named `<node>-plan-<digest>`, `<node>-plan-input-<digest>`, and
+  `<node>-connectivity-<digest>`, replaced when the plan changes
+- a short-lived planning Pod named `<node>-planner-...` while a new plan is computed
+- a PersistentVolumeClaim named after the Node when persistence is enabled
+
+Per namespace:
+
+- the headless `c9s-management-mesh` Service that discovers management mesh members
+- the `c9s-peer-directory` ConfigMap that maps node names to management addresses
+- a `direct-device-ca-...` Secret holding the lab CA, plus one `<node>-certificates-...`
+  Secret per Node that sets `certificate.issue`
+
+Do not edit these objects. The controller owns them and reverts drift.
+
+## Node status
+
+```bash
+kubectl get nodes.c9s.run
+kubectl get nodes.c9s.run -o wide
+```
+
+`READINESS` is `ready`, `notready`, or `unknown`. The wide view adds the container,
+preparation, and connectivity conditions, the plan digest, and the applied NodeProfile.
+`kubectl describe` shows every condition:
+
+| Condition | Meaning |
+| --- | --- |
+| `NodeProfileResolved` | the referenced NodeProfile exists |
+| `PlanApplied` | the current spec was planned and rendered; when `False`, the reason names the cause, for example `PlanPending`, `ImagePullSecretMissing`, `OCIMetadataResolveManifest`, or `DeploymentInvalid` |
+| `Prepared` | the preparation init container staged and verified every file |
+| `ConnectivityReady` | every interface of the cold-start plan exists |
+| `ContainersReady` | every application container of the Node runs and passes its probes |
+| `LinkLifecycleAction` | the action taken for the latest Link-only change: `live`, `restart`, or `recreate` |
+| `DeviceStateReset` | progress of a device-state reset, see [Persistent storage](/docs/guides/persistence) |
+
+A spec change flips readiness to `notready` at once, with `PlanApplied=False` and reason
+`PlanPending`, and readiness returns when the new plan is applied. Wait for a Node with:
+
+```bash
+kubectl wait nodes.c9s.run/srl1 --for=jsonpath='{.status.readiness}'=ready --timeout=10m
+```
+
+Every condition change also produces an event on the Node:
+
+```bash
+kubectl get events --field-selector involvedObject.kind=Node,involvedObject.name=srl1
+```
+
+The status also records the allocated management address under `status.directManagement` and
+the exposed ports under `status.exposedPorts`.
+
+## Link and Topology status
+
+```bash
+kubectl get links.c9s.run
+```
+
+This shows both endpoints, the allocated wire id, and the `Accepted` condition, which is
+`False` when an endpoint Node does not exist or the endpoints are invalid. Dataplane state is
+not on the Link: it is visible through the endpoint Nodes' `ConnectivityReady` condition and
+the `clabwire` container log.
+
+```bash
+kubectl get topologies.c9s.run
+```
+
+This shows the Topology state (`deploying`, `running`, `degraded`, or `deployfailed`) and
+readiness. The readiness refers to the current definition only once `status.observedGeneration`
+equals `metadata.generation`. `status.error` names a compile error or name conflict that blocks
+the Topology.
+
+## Logs and shell access
+
+Unqualified `kubectl logs` and `kubectl exec` target the device container:
+
+```bash
+kubectl logs deploy/srl1
+kubectl exec -it deploy/srl1 -- sr_cli
+```
+
+The other containers of the Pod:
+
+```bash
+kubectl logs deploy/srl1 -c planner    # preparation: staged and preserved files
+kubectl logs deploy/srl1 -c clabwire   # connectivity: wires, carrier, management mesh
+```
+
+Chassis cards and grouped nodes are separate application containers. List them with
+`kubectl get pod <pod> -o jsonpath='{.spec.containers[*].name}'` and select one with `-c`.
+
+## Packet capture
+
+The connectivity sidecar streams a pcap for any interface it realized for a Node. Address the
+Node by its UID and the interface by the name the Link uses:
+
+```bash
+NODE_UID=$(kubectl get nodes.c9s.run srl1 -o jsonpath='{.metadata.uid}')
+kubectl exec deploy/srl1 -c clabwire -- /clabernetes/manager node-runtime packet-capture \
+  --plan /var/run/clabernetes/plan/plan.json \
+  --input /var/run/clabernetes/input/input.json \
+  --connectivityRevision /var/run/clabernetes/connectivity-revision/revision.json \
+  --nodeID "$NODE_UID" --interface e1-1 --duration 30s > e1-1.pcap
+```
+
+`--duration` and `--packetLimit` bound the capture, and the first bound reached ends it. The
+output is a standard pcap file for Wireshark or `tcpdump -r`.
+
+## Network policies
+
+Device Pods talk to each other over UDP: port 14789 carries the management mesh and port 14790
+the link wires. The connectivity sidecar also watches Links through the Kubernetes API. If
+NetworkPolicies restrict traffic in a lab namespace, allow both ports between device Pods and
+egress to the API server.
+
+## Related
+
+- [Nodes and Links](/docs/concepts/nodes-and-links)
+- [Link wire semantics](/docs/guides/link-wire)
+- [Persistent storage](/docs/guides/persistence)
+- [Image pulling](/docs/guides/image-pull#troubleshooting)

--- a/docs/guides/management-network.md
+++ b/docs/guides/management-network.md
@@ -102,9 +102,15 @@ Services and external destinations stay reachable through ordinary Kubernetes ne
 
 ## Name resolution
 
-Lab members also resolve each other by node name: each node has a namespace-local Service
-named after it, and declared `aliases` add extra headless Services bound to the same Pod. A
-device can target `srl2` or a declared alias instead of a management address.
+Inside a device, every node name in the namespace, every declared alias, and every chassis
+component name resolves to that node's management address. c9s writes these entries into the
+Pod's `/etc/hosts` from a namespace-wide peer directory and updates them as nodes join or
+leave, without restarting any Pod. A device can therefore target `srl2` exactly as on
+containerlab's management network, on any port.
+
+Other workloads in the cluster reach a node through its Services instead: the expose Service
+named after the node and one headless Service per alias, both as
+`<name>.<namespace>.svc.cluster.local`.
 
 ## Related
 

--- a/docs/guides/meta.yaml
+++ b/docs/guides/meta.yaml
@@ -1,9 +1,11 @@
 title: Guides
 icon: Map
 pages:
+  - lab-operations
   - expose-configuration
   - management-network
   - file-mounting
+  - clabverter
   - image-pull
   - mtu
   - link-wire

--- a/docs/guides/mtu.md
+++ b/docs/guides/mtu.md
@@ -73,7 +73,7 @@ network). Two things keep that from surprising a device:
   size the application fixes and cannot lower (SR OS presents 1514). Their handshakes crossing
   the mesh have the advertised maximum segment lowered to what the mesh carries, so both peers
   send segments that fit. Without it these flows are a black hole: the connection completes and
-  then stalls on the first full-size segment -- a TLS certificate, a NETCONF hello -- because a
+  then stalls on the first full-size segment (a TLS certificate, a NETCONF hello) because a
   drop on a veth produces no fragmentation-needed to learn from. The clamp only ever lowers a
   size, and only on the management mesh; lab links keep the MTU the topology asked for.
 

--- a/docs/guides/nokia-srsim.md
+++ b/docs/guides/nokia-srsim.md
@@ -39,9 +39,8 @@ spec:
       - srsim-registry
 ```
 
-The kubelet receives this name through `Pod.spec.imagePullSecrets`. Configure registry mirrors,
-private CAs, or HTTP endpoints in the worker container runtime; c9s has no nested Docker or image
-import fallback.
+See [Image pulling](/docs/guides/image-pull) for a cluster-wide pull Secret default, registry
+mirrors, and private CAs.
 
 ## Supported Configurations
 
@@ -102,7 +101,6 @@ spec:
           sr1:
             kind: nokia_srsim
             type: sr-1
-            startup-config: sr1-config.cfg
           sr2:
             kind: nokia_srsim
             type: sr-1s
@@ -197,7 +195,7 @@ The structured `veth` endpoints above compile to the same c9s Link as brief endp
 `srsim`; the planned card containers are directly visible application containers of that Pod, so
 `kubectl logs` and `kubectl exec` reach a specific card with `-c`. An empty `components: []`
 declaration is also accepted for SR-SIM images that use Containerlab's default component
-expansion, including the issue-269 topology shape. In every component form, Clabernetes requires
+expansion. In every component form, Clabernetes requires
 one namespace owner and verifies that every dependent component resolves into that namespace;
 invalid ownership fails planning rather than selecting a card arbitrarily.
 
@@ -266,9 +264,12 @@ spec:
             network-mode: container:srsim-a
             env:
               NOKIA_SROS_SLOT: "1"
+          client:
+            kind: linux
+            image: ghcr.io/srl-labs/network-multitool:latest
         links:
-          # Links to other chassis or external devices cross the cluster fabric
-          - endpoints: ["srsim-iom1:1/1/c1/1", "external-router:e1-1"]
+          # Links to other chassis or nodes leave the Pod over the cluster fabric
+          - endpoints: ["srsim-iom1:1/1/c1/1", "client:eth1"]
 ```
 
 **Key points for distributed mode:**
@@ -466,17 +467,10 @@ attachment stops reconciliation instead of silently choosing one license.
 
 All cards (CPM-A, CPM-B, IOMs) within a single distributed chassis must run on the same Kubernetes worker node. This is a fundamental constraint of Linux network namespaces: they cannot span multiple hosts.
 
-**Impact:** A single Kubernetes worker must have sufficient resources (CPU, memory) for all cards in a chassis.
-
-**Mitigations:**
-
-- Use Kubernetes node selectors or taints/tolerations to ensure chassis pods are scheduled on appropriately sized nodes
-- Consider using integrated SR-SIM types (sr-1, sr-1s) when resource constraints are a concern
-- Plan cluster capacity with distributed chassis resource requirements in mind
-
-### Different Chassis Can Be Distributed
-
-While cards within a chassis must be co-located, different chassis (routers) in your topology can be scheduled on different Kubernetes worker nodes. For example, if you have two SR-7 routers in your topology, each can run on a different worker node; only the cards within each individual router must share a node.
+A single Kubernetes worker must therefore have enough CPU and memory for all cards of a chassis.
+Use node selectors or tolerations to place chassis Pods on suitably sized workers, or use an
+integrated type such as `sr-1` when resources are tight. Different chassis in one topology can
+still run on different workers.
 
 ### Port Publishing
 

--- a/docs/guides/nokia-srsim.md
+++ b/docs/guides/nokia-srsim.md
@@ -199,7 +199,7 @@ expansion. In every component form, Clabernetes requires
 one namespace owner and verifies that every dependent component resolves into that namespace;
 invalid ownership fails planning rather than selecting a card arbitrarily.
 
-The same Containerlab definition can be converted with `clabverter --emit-crs`. The imported
+The same Containerlab definition can be converted with `clabverter --emitCRs`. The imported
 containerlab package remains responsible for component expansion and fabric construction, while
 Clabernetes owns the Kubernetes Node, device Pod, readiness, and shared payload lifecycle.
 

--- a/docs/guides/persistence.md
+++ b/docs/guides/persistence.md
@@ -71,11 +71,7 @@ spec:
       storageClassName: "fast-ssd"
 ```
 
-**Storage class recommendations:**
-
-- Use `ReadWriteOnce` capable storage classes
-- SSD-backed storage for better performance
-- Avoid network-attached storage for latency-sensitive workloads
+The storage class must support `ReadWriteOnce` volumes.
 
 ### Direct Node and NodeProfile Persistence
 
@@ -114,9 +110,9 @@ On every Pod start, preparation regenerates and verifies the planned artifacts, 
 per file what to publish:
 
 - **A file the device has modified since it was last staged is left in place.** Saving your
-  configuration on the node (for example `tools system configuration save` on SR Linux, or the
-  Save lifecycle described below) makes that saved state the boot state of every later Pod,
-  regardless of whether the startup configuration was CLI-format or a full config file.
+  configuration on the node (for example `tools system configuration save` on SR Linux) makes
+  that saved state the boot state of every later Pod, regardless of whether the startup
+  configuration was CLI-format or a full config file.
 - **A file the device never touched follows the spec.** Updated topology files, certificates,
   and repo files keep propagating.
 - **Everything the device wrote at unplanned paths** inside the persisted directories (SSH host
@@ -190,12 +186,9 @@ kubectl delete pvc srl1
 
 ## Saving Configuration
 
-The Save lifecycle runs the imported kind's own save behavior (for SR Linux,
-`tools system configuration save`) inside the device container. Saving on the device directly
-works exactly as well; the lifecycle entrypoint simply gives every kind one uniform verb.
-
-Running a save against a node **without** persistence still succeeds, but its output carries a
-warning that the saved configuration cannot survive Pod replacement.
+Save on the device with its own command, for example `tools system configuration save` on SR
+Linux. The saved file lands in a persisted directory and becomes the boot state of every later
+Pod. Without persistence, a saved configuration is lost when the Pod is replaced.
 
 ## Important Limitations
 
@@ -214,15 +207,15 @@ claimSize: "10Gi"
 claimSize: "3Gi"  # Will be ignored
 ```
 
-To use a smaller claim, delete the topology and recreate it.
+To use a smaller claim, delete the Node (or its Topology) and recreate it.
 
 ### Storage Class Is Immutable
 
 The storage class cannot be changed after PVC creation. To change storage class:
 
-1. Backup any important data
-2. Delete the topology
-3. Recreate with new storage class
+1. Back up any important data
+2. Delete the Node (or its Topology), and delete a retained claim as well
+3. Recreate with the new storage class
 
 ### Node Removal Removes the Claim Unless Retained
 
@@ -309,22 +302,6 @@ kubectl describe pod <pod-name> | grep -A10 "Volumes"
 That is the saved-configuration-wins contract at work: a saved configuration shadows startup
 config updates. Set `enforce-startup-config: true` or run a device-state reset to make the
 declared configuration win.
-
-### Slow Performance
-
-Consider:
-
-- Using a faster storage class
-- Reducing claim size to what's actually needed
-- Using local storage for development
-
-## Best Practices
-
-1. **Size appropriately**: Start with recommended sizes, increase as needed
-2. **Use appropriate storage class**: Match performance requirements
-3. **Regular backups**: Persistence doesn't replace backups
-4. **Clean up retained claims**: Remove unused PVCs to free resources
-5. **Monitor usage**: Watch for PVCs nearing capacity
 
 ## Related
 

--- a/docs/guides/resource-management.md
+++ b/docs/guides/resource-management.md
@@ -115,24 +115,7 @@ spec:
         cpu: "1"
 ```
 
-### Resources by Containerlab Kind
-
-Per-kind resource defaults are no longer configured in c9s: the imported containerlab package
-owns kind requirements, and generic defaults come from `config.deployment.resourcesDefault`. Use
-a `NodeProfile` when a specific group of nodes needs different sizing:
-
-```yaml
-apiVersion: c9s.run/v1alpha1
-kind: Config
-metadata:
-  name: clabernetes
-spec:
-  deployment:
-    resourcesDefault:
-      requests:
-        memory: "512Mi"
-        cpu: "250m"
-```
+There are no per-kind defaults. Use a NodeProfile when a group of nodes needs different sizing.
 
 ### Containerlab `cpu` and `memory`
 
@@ -241,30 +224,6 @@ spec:
         - key: "nvidia.com/gpu"
           operator: "Exists"
           effect: "NoSchedule"
-```
-
-### Toleration Examples
-
-```yaml
-# Tolerate specific taint
-tolerations:
-  - key: "node-role.kubernetes.io/network"
-    operator: "Equal"
-    value: "true"
-    effect: "NoSchedule"
-
-# Tolerate any value for a key
-tolerations:
-  - key: "dedicated"
-    operator: "Exists"
-    effect: "NoSchedule"
-
-# Tolerate with time limit
-tolerations:
-  - key: "node.kubernetes.io/unreachable"
-    operator: "Exists"
-    effect: "NoExecute"
-    tolerationSeconds: 300
 ```
 
 ### Taint Your Nodes
@@ -442,24 +401,15 @@ kubectl top nodes
 kubectl describe node <node-name> | grep -A5 "Allocated"
 ```
 
-## Best Practices
-
-1. **Always set requests**: Ensure scheduler knows resource needs
-2. **Set appropriate limits**: Prevent runaway resource usage
-3. **Use node selectors wisely**: Don't over-constrain scheduling
-4. **Test tolerations**: Verify pods can run on intended nodes
-5. **Monitor resource usage**: Adjust based on actual consumption
-
 ## Privileged Mode
 
-There is no privileged wrapper pod and no `privilegedLauncher` knob. Each device container
-receives exactly the privilege, capabilities, and devices its imported containerlab kind plan
-declares, including any `privileged`, `cap-add`, or `devices` vocabulary in the node
-definition itself. Privilege is per-container plan output, never profile or Config policy.
+Each device container receives exactly the privilege, capabilities, and devices its containerlab
+kind declares, including any `privileged`, `cap-add`, or `devices` vocabulary in the node
+definition itself. Privilege is never a NodeProfile or Config setting.
 
 ## Related
 
 - [Example: with-resources.yaml](https://github.com/clabernetes/clabernetes/blob/main/examples/deployment/with-resources.yaml)
 - [Example: with-scheduling.yaml](https://github.com/clabernetes/clabernetes/blob/main/examples/deployment/with-scheduling.yaml)
 - [CRD Reference: Deployment](/docs/crd/topology)
-- [CRD Reference: Scheduling](/docs/guides/resource-management)
+- [CRD Reference: NodeProfile](/docs/crd/node-profile)

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -23,6 +23,10 @@ A typical installation method uses the [c9s Helm chart](https://github.com/clabe
   Link wires need nothing special; they are plain UDP between the connectivity sidecars.
 - **`/dev/kvm` on workers** only when running VM-backed (vrnetlab) kinds; the plan requests the
   device through ordinary Kubernetes device semantics.
+- **Pod-to-Pod UDP in lab namespaces**: device Pods exchange management mesh traffic on UDP
+  14789 and link wires on UDP 14790, and their connectivity sidecar watches Links through the
+  Kubernetes API. NetworkPolicies must allow both ports between device Pods and egress to the
+  API server.
 - **Registry access is cluster administration**: private device images use ordinary
   `imagePullSecrets`, and mirrors or insecure registries are configured on the workers'
   container runtime, not in c9s. See [Image pulling](/docs/guides/image-pull).

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -4,8 +4,6 @@ description: Install c9s into an existing Kubernetes cluster.
 icon: Download
 ---
 
-
-
 C9s can be installed into an existing Kubernetes cluster with version 1.31 or higher. No custom CNI, no additional storage class, no special tuning.
 
 A typical installation method uses the [c9s Helm chart](https://github.com/clabernetes/clabernetes/pkgs/container/clabernetes%2Fclabernetes) distributed as an OCI artifact.
@@ -15,9 +13,10 @@ A typical installation method uses the [c9s Helm chart](https://github.com/clabe
 - **Kubernetes 1.31 or newer.** The direct runtime relies on restartable init containers
   (native sidecars) and server-side field selectors for Link watches.
 - **Privileged workloads must be admitted** in lab namespaces: every device Pod runs a
-  privileged connectivity init-sidecar that owns interposition, fabric, and host-Link wiring
-  pod-locally. No node-resident agent is installed. Device containers themselves receive only
-  the privilege their imported kind plan declares.
+  privileged connectivity init-sidecar that wires the Pod's interfaces. If Pod Security
+  Admission is enforced, label lab namespaces with
+  `pod-security.kubernetes.io/enforce=privileged`. No node-resident agent is installed, and
+  device containers themselves receive only the privilege their containerlab kind declares.
 - **VXLAN and nftables support in the worker kernel** (standard in distribution kernels):
   the namespace-wide management mesh is kernel VXLAN inside the Pods on the CNI network, and
   management translation uses an nftables table inside each Pod's namespace. Cross-worker
@@ -26,7 +25,7 @@ A typical installation method uses the [c9s Helm chart](https://github.com/clabe
   device through ordinary Kubernetes device semantics.
 - **Registry access is cluster administration**: private device images use ordinary
   `imagePullSecrets`, and mirrors or insecure registries are configured on the workers'
-  container runtime, not in c9s.
+  container runtime, not in c9s. See [Image pulling](/docs/guides/image-pull).
 
 ## Versions
 
@@ -111,8 +110,35 @@ make install VERSION=main
 specific context:
 
 ```bash
- C9S_CONTEXT=my-cluster make install
+C9S_CONTEXT=my-cluster make install
 ```
+
+## Verify the installation
+
+```bash
+kubectl -n c9s get pods
+```
+
+The manager Pods must be `Running`. Then deploy a lab, for example one of the
+[basic examples](/docs/examples).
+
+## Global configuration
+
+Cluster-wide defaults (pull policy and pull Secrets, default resources, node selectors by image,
+registry trust and mirrors) live in one `Config` resource named `clabernetes` in the c9s
+namespace. The Helm chart creates it from the `globalConfig` values. On later upgrades the chart
+only fills fields that are still unset in the Config; set `globalConfig.mergeMode: overwrite` to
+have the chart values replace the whole resource on every upgrade. When the release is managed
+by Argo CD or Flux, set `globalConfig.enabled: false` and apply the Config yourself.
+
+Edit the Config directly when you do not manage it through Helm values:
+
+```bash
+kubectl -n c9s edit configs.c9s.run clabernetes
+```
+
+The manager picks up changes immediately and re-evaluates every Node. See the
+[Config reference](/docs/crd/config) for all fields.
 
 ## Upgrade
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ icon: Rocket
 ---
 
 The [repository](https://github.com/clabernetes/clabernetes) includes an automated workflow that creates a single-node [KinD](https://kind.sigs.k8s.io/) cluster, installs the
-selected c9s Helm chart, configures MetalLB, and deploys a sample network topology consisting of an Nokia SR Linux node connected to a Network Multitool node.
+selected c9s Helm chart, configures MetalLB, and deploys a sample network topology consisting of a Nokia SR Linux node connected to a Network Multitool node.
 
 ## Requirements
 
@@ -35,7 +35,7 @@ From the repository root, run:
 make try-c9s
 ```
 
-This command creates a single-node KinD cluster, installs c9s, configures Kubernetes load balancer (MetalLB) and deploys a sample network topology consisting of an Nokia SR Linux node connected to a Network Multitool node.
+This command creates a single-node KinD cluster, installs c9s, configures Kubernetes load balancer (MetalLB) and deploys a sample network topology consisting of a Nokia SR Linux node connected to a Network Multitool node.
 
 A successful run ends with the following output:
 
@@ -55,12 +55,12 @@ The previous step ends with the list of commands to use to connect to the two no
 
 <TryC9sDiagram />
 
-The list of connection commands show you how to connect:
+The connection commands show you how to connect:
 
 - with SSH/gNMI/NETCONF to the Nokia SR Linux node deployed in the lab and
 - with SSH to the Network Multitool node deployed in the lab.
 
-Connect to the SR Linux node using SSH, you should see the login prompt for the admin user, enter the `NokiaSrl1!` to log in.
+Connect to the SR Linux node with SSH and log in as `admin` with the password `NokiaSrl1!`.
 
 ## Test the datapath [step]
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -89,6 +89,7 @@ make try-c9s-clean
 ## Next steps
 
 - [Understand Nodes and Links API](/docs/concepts/nodes-and-links)
+- [Operate a lab: status, logs, packet capture](/docs/guides/lab-operations)
 - [See what differs from containerlab](/docs/concepts/containerlab-differences)
 - [Read the architecture overview](/docs/architecture)
 - [Browse complete examples](/docs/examples)


### PR DESCRIPTION
## Summary

Started as documenting `Config.spec.imagePull.pullSecrets`; widened into a general docs pass for correctness, missing context, and readability.

**Fixes**

- Config CRD page claimed Config only applies when a Node has no NodeProfile. Config is the base and the profile overrides only the fields it sets.
- SR-SIM distributed example linked to an undefined `external-router` node and used an unresolvable `startup-config` file path.
- Resource guide "Related" link pointed at itself; legacy `privilegedLauncher` wording removed.
- Persistence guide referred to a "Save lifecycle" with no user-facing command; now describes saving on the device.
- Quickstart grammar, em-dash style in two pages.

**Missing context added**

- Installation: a "Global configuration" section (Config name and namespace, Helm `globalConfig` seeding, merge vs overwrite, live reload), a verify step, and the Pod Security Admission label for lab namespaces.
- Image pulling: global pull Secret default, what happens when a namespace lacks the Secret (`ImagePullSecretMissing`), per-namespace opt-out via `pullSecrets: []`, Helm values path, accepted Secret types, and simpler wording for registry trust and mirrors.

**Trimmed**

- Generic Kubernetes "Best Practices" lists and toleration examples across the expose, file-mounting, persistence, and resource guides.
- `disableExpose` upgrade walkthrough reduced to a short notice.
- Duplicate sections in the SR-SIM and resource guides.

## Validation

- `make check-docs`
