### PR TITLE
fix: stop rejecting plans for probe passwords the topology already declares

### DIFF
--- a/controllers/node/direct.go
+++ b/controllers/node/direct.go
@@ -185,6 +185,9 @@ func (r *Reconciler) reconcileDirect(
 	if err != nil {
 		return err
 	}
+	// Definitions never change across discovery rounds, so the declared text that screens the
+	// sensitive-value set is fixed for the whole reconcile.
+	declaredText := declaredNodeText(declaredInput)
 	metadataResolver := *r.ImageMetadataResolver
 	metadataResolver.Platform = r.DirectPlatform
 	registryMetadataTrust, err := compileRegistryMetadataTrust(
@@ -227,9 +230,10 @@ func (r *Reconciler) reconcileDirect(
 	if err != nil {
 		return err
 	}
-	sensitiveValues := append(
-		slices.Clone(declaredMetadata.SensitiveValues),
-		entropyResolution.SensitiveValues...,
+	sensitiveValues := screenSensitiveValues(
+		declaredText,
+		declaredMetadata.SensitiveValues,
+		entropyResolution.SensitiveValues,
 	)
 	imagePullSecrets := declaredMetadata.PullSecrets
 	planInput := clabernetesinternaldeviceplan.Input{}
@@ -293,9 +297,10 @@ func (r *Reconciler) reconcileDirect(
 		if compileErr != nil {
 			return compileErr
 		}
-		sensitiveValues = append(
-			slices.Clone(discoveredMetadata.SensitiveValues),
-			entropyResolution.SensitiveValues...,
+		sensitiveValues = screenSensitiveValues(
+			declaredText,
+			discoveredMetadata.SensitiveValues,
+			entropyResolution.SensitiveValues,
 		)
 		imagePullSecrets = discoveredMetadata.PullSecrets
 		if reflect.DeepEqual(discoveryInput.Images, nextInput.Images) {
@@ -350,7 +355,11 @@ func (r *Reconciler) reconcileDirect(
 	if err != nil {
 		return err
 	}
-	sensitiveValues = append(sensitiveValues, certificateResolution.SensitiveValues...)
+	sensitiveValues = screenSensitiveValues(
+		declaredText,
+		sensitiveValues,
+		certificateResolution.SensitiveValues,
+	)
 	planningResult, err := r.PlannerReconciler.Reconcile(ctx, PlannerAttempt{
 		Node: node, Input: planInput, SensitiveValues: sensitiveValues,
 		Image: r.DirectRuntimeImage, PlannerRevision: clabernetesconstants.Version,
@@ -394,7 +403,11 @@ func (r *Reconciler) reconcileDirect(
 	if err != nil {
 		return err
 	}
-	sensitiveValues = append(sensitiveValues, probeResolution.SensitiveValues...)
+	sensitiveValues = screenSensitiveValues(
+		declaredText,
+		sensitiveValues,
+		probeResolution.SensitiveValues,
+	)
 	persistentVolumeClaims, err := r.reconcileDirectPersistentVolumeClaims(
 		ctx,
 		groupMembers,

--- a/controllers/node/direct_test.go
+++ b/controllers/node/direct_test.go
@@ -2340,3 +2340,212 @@ func TestAppendDirectPayloadToleratesContentIdenticalGroupDeclarations(t *testin
 		t.Fatalf("content conflict error = %v", err)
 	}
 }
+
+// directProbeTestProfile enables an SSH status probe whose password is the only Secret-backed
+// value the plan artifact guards screen for in these tests.
+func directProbeTestProfile(namespace, password string) *clabernetesapisv1alpha1.NodeProfile {
+	return &clabernetesapisv1alpha1.NodeProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "probed", Namespace: namespace, UID: "probed-uid"},
+		Spec: clabernetesapisv1alpha1.NodeProfileSpec{
+			StatusProbes: &clabernetesapisv1alpha1.StatusProbes{
+				Enabled: true,
+				ProbeConfiguration: clabernetesapisv1alpha1.ProbeConfiguration{
+					SSHProbeConfiguration: &clabernetesapisv1alpha1.SSHProbeConfiguration{
+						Username: "admin", Password: password,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newDirectProbeTestHarness(
+	t *testing.T,
+	node *clabernetesapisv1alpha1.Node,
+	profile *clabernetesapisv1alpha1.NodeProfile,
+) (ctrlruntimeclient.Client, *Reconciler) {
+	t.Helper()
+
+	node.Spec.ProfileRef = &k8scorev1.LocalObjectReference{Name: profile.GetName()}
+
+	scheme := plannerTestScheme(t)
+	if err := k8sappsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&clabernetesapisv1alpha1.Node{}).WithObjects(node, profile).Build()
+	reconciler := NewReconciler(
+		&claberneteslogging.FakeInstance{}, client, client, "clabernetes",
+		clabernetesconfig.GetFakeManager,
+	)
+	reconciler.DirectRuntimeImage = "example/c9s-manager@sha256:cccccccc"
+	reconciler.DirectCompatibility = func() (clabernetesinternaldeviceplan.Compatibility, error) {
+		return planInputTestCompatibility(), nil
+	}
+	reconciler.DirectPlatform = clabernetesinternalocimetadata.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	reconciler.ImageMetadataResolver.Resolver = &fakeOCIMetadataResolver{
+		result: &clabernetesinternalocimetadata.Metadata{
+			SchemaVersion:   clabernetesinternalocimetadata.SchemaVersion,
+			DigestReference: "registry.example/device@sha256:" + strings.Repeat("a", 64),
+		},
+	}
+	reconciler.ImageDiscoveryReconciler.ReadLogs = directTestWorkerLogs(t, client)
+	reconciler.PlannerReconciler.ReadLogs = directTestWorkerLogs(t, client)
+
+	return client, reconciler
+}
+
+func TestDirectPlanAcceptsProbePasswordDeclaredInDefinition(t *testing.T) {
+	ctx := context.Background()
+	node := planInputTestNode(
+		"future-a",
+		"uid-future-a",
+		"future-package-kind",
+		"registry.example/device:1",
+	)
+	// The definition restates the probe password the way a cEOS startup-config restates its
+	// admin user: the value is plain text on the Node before any artifact exists, so screening
+	// generated artifacts for it protects nothing and must not reject the plan.
+	node.Spec.StartupConfig = "hostname future-a\nusername admin privilege 15 secret 0 admin\n"
+	client, reconciler := newDirectProbeTestHarness(
+		t,
+		node,
+		directProbeTestProfile(node.GetNamespace(), "admin"),
+	)
+
+	deployment := reconcileDirectTestDeployment(ctx, t, reconciler, client, node)
+
+	plans := &k8scorev1.ConfigMapList{}
+	if err := client.List(
+		ctx,
+		plans,
+		ctrlruntimeclient.InNamespace(node.GetNamespace()),
+		ctrlruntimeclient.MatchingLabels{
+			clabernetesconstants.LabelComponent: planComponentLabelValue,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(plans.Items) != 1 {
+		t.Fatalf("plan ConfigMaps = %d, want 1", len(plans.Items))
+	}
+
+	if !slices.ContainsFunc(
+		deployment.Spec.Template.Spec.Volumes,
+		func(volume k8scorev1.Volume) bool {
+			return volume.ConfigMap != nil && volume.ConfigMap.Name == plans.Items[0].GetName()
+		},
+	) {
+		t.Fatalf("direct workload does not mount plan %q: %#v",
+			plans.Items[0].GetName(),
+			deployment.Spec.Template.Spec.Volumes,
+		)
+	}
+
+	stored := &clabernetesapisv1alpha1.Node{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(node), stored); err != nil {
+		t.Fatal(err)
+	}
+
+	if !apimachinerymeta.IsStatusConditionTrue(
+		stored.Status.Conditions,
+		clabernetesapisv1alpha1.NodeConditionPlanApplied,
+	) {
+		t.Fatalf("Node conditions = %#v, want PlanApplied=True", stored.Status.Conditions)
+	}
+}
+
+func TestDirectPlanRejectionForUndeclaredSensitiveValueIsReportedOnNode(t *testing.T) {
+	ctx := context.Background()
+	node := planInputTestNode(
+		"future-a",
+		"uid-future-a",
+		"future-package-kind",
+		"registry.example/device:1",
+	)
+	// "sha256" appears in every digest-pinned image reference of the planner input but nowhere
+	// in the declared definition, so it keeps its protection: the guard must refuse to publish
+	// and the refusal must be visible on the Node rather than only in the manager log.
+	client, reconciler := newDirectProbeTestHarness(
+		t,
+		node,
+		directProbeTestProfile(node.GetNamespace(), "sha256"),
+	)
+	eventRecorder := clientgoevents.NewFakeRecorder(16)
+	reconciler.EventRecorder = eventRecorder
+
+	var err error
+
+	for range 10 {
+		if err = reconciler.Reconcile(ctx, node); err != nil {
+			break
+		}
+
+		completeDirectTestWorkers(ctx, t, client, node.GetNamespace())
+	}
+
+	if !errors.Is(err, ErrInvalidPlanArtifact) {
+		t.Fatalf("direct reconcile error = %v, want ErrInvalidPlanArtifact", err)
+	}
+
+	deployment := &k8sappsv1.Deployment{}
+	if getErr := client.Get(
+		ctx,
+		ctrlruntimeclient.ObjectKeyFromObject(node),
+		deployment,
+	); !apimachineryerrors.IsNotFound(getErr) {
+		t.Fatalf("rejected plan produced a workload: %v %#v", getErr, deployment)
+	}
+
+	plans := &k8scorev1.ConfigMapList{}
+	if err = client.List(
+		ctx,
+		plans,
+		ctrlruntimeclient.InNamespace(node.GetNamespace()),
+		ctrlruntimeclient.MatchingLabels{
+			clabernetesconstants.LabelComponent: planComponentLabelValue,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(plans.Items) != 0 {
+		t.Fatalf("rejected plan was persisted: %#v", plans.Items)
+	}
+
+	stored := &clabernetesapisv1alpha1.Node{}
+	if err = client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(node), stored); err != nil {
+		t.Fatal(err)
+	}
+
+	condition := apimachinerymeta.FindStatusCondition(
+		stored.Status.Conditions,
+		clabernetesapisv1alpha1.NodeConditionPlanApplied,
+	)
+	if condition == nil || condition.Status != metav1.ConditionFalse ||
+		condition.Reason != "PlanRejected" ||
+		!strings.Contains(condition.Message, "sensitive value") ||
+		strings.Contains(condition.Message, "sha256") {
+		t.Fatalf("PlanApplied condition = %#v, want PlanRejected without the value", condition)
+	}
+
+	if stored.Status.Readiness != clabernetesconstants.NodeStatusNotReady {
+		t.Fatalf("readiness = %q, want %q",
+			stored.Status.Readiness,
+			clabernetesconstants.NodeStatusNotReady,
+		)
+	}
+
+	events := drainDirectStatusEvents(eventRecorder)
+	if !slices.ContainsFunc(events, func(event string) bool {
+		return strings.Contains(event, "Warning PlanRejected") &&
+			strings.Contains(event, "sensitive value") && !strings.Contains(event, "sha256")
+	}) {
+		t.Fatalf("direct preflight events = %#v", events)
+	}
+}

--- a/controllers/node/directstatus.go
+++ b/controllers/node/directstatus.go
@@ -254,6 +254,21 @@ func directPreflightDiagnostic(err error) (reason, message string, report bool) 
 		return "ImagePullSecretUnreadable", pullSecretErr.Error(), true
 	}
 
+	if errors.Is(err, ErrInvalidPlanArtifact) || errors.Is(err, ErrInvalidPlannerInput) {
+		// The controller refused to publish a generated artifact (malformed, oversized, or
+		// carrying a sensitive value). The refusal repeats identically on every reconcile, so
+		// without a condition the Node keeps its last status while only the manager log shows
+		// why the workload never rolls.
+		return "PlanRejected", err.Error(), true
+	}
+
+	if errors.Is(err, ErrPlanArtifactConflict) || errors.Is(err, ErrPlannerInputConflict) ||
+		errors.Is(err, ErrWorkerOutputConflict) {
+		// A foreign object occupies the content-addressed name of an immutable artifact;
+		// planning cannot progress until that object is removed.
+		return "PlanArtifactConflict", err.Error(), true
+	}
+
 	if applyErr, ok := errors.AsType[*deploymentApplyError](err); ok {
 		// The API server rejecting the rendered Deployment is terminal until the spec changes;
 		// anything else (a timeout, a conflict) is retried and may clear on its own.

--- a/controllers/node/directstatus_test.go
+++ b/controllers/node/directstatus_test.go
@@ -3,6 +3,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -978,5 +979,92 @@ func TestObserveDirectContainersAcceptsIndexDigestWhenSpecIsPinned(t *testing.T)
 
 	if unpinnedReady {
 		t.Fatal("mismatched runtime identity was accepted without a pinned spec reference")
+	}
+}
+
+func TestReportDirectPreflightFailureStampsPlanArtifactErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantReason string
+	}{
+		{
+			name: "plan artifact carries a sensitive value",
+			err: fmt.Errorf(
+				"%w: plan input contains a sensitive value",
+				ErrInvalidPlanArtifact,
+			),
+			wantReason: "PlanRejected",
+		},
+		{
+			name: "planner input is oversized",
+			err: fmt.Errorf(
+				"%w: input size 9 is outside 1..4 bytes",
+				ErrInvalidPlannerInput,
+			),
+			wantReason: "PlanRejected",
+		},
+		{
+			name:       "foreign object at the plan name",
+			err:        fmt.Errorf("%w lab/router-plan-0123456789ab", ErrPlanArtifactConflict),
+			wantReason: "PlanArtifactConflict",
+		},
+		{
+			name: "foreign object at the worker output name",
+			err: fmt.Errorf(
+				"%w: record is not a framed worker output",
+				ErrWorkerOutputConflict,
+			),
+			wantReason: "PlanArtifactConflict",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := nodeReconcileTestScheme(t)
+			node := nodeReconcileTestNode()
+			client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&clabernetesapisv1alpha1.Node{}).WithObjects(node).Build()
+			reconciler := &Reconciler{Client: client, apiReader: client}
+
+			if err := reconciler.reportDirectPreflightFailure(
+				context.Background(),
+				node,
+				test.err,
+			); err != nil {
+				t.Fatalf("reportDirectPreflightFailure() error = %v", err)
+			}
+
+			stored := &clabernetesapisv1alpha1.Node{}
+			if err := client.Get(
+				context.Background(),
+				ctrlruntimeclient.ObjectKeyFromObject(node),
+				stored,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			condition := apimachinerymeta.FindStatusCondition(
+				stored.Status.Conditions,
+				clabernetesapisv1alpha1.NodeConditionPlanApplied,
+			)
+			if condition == nil || condition.Status != metav1.ConditionFalse ||
+				condition.Reason != test.wantReason ||
+				!strings.Contains(condition.Message, test.err.Error()) ||
+				!strings.Contains(condition.Message, "left unchanged") {
+				t.Fatalf("PlanApplied condition = %#v, want reason %q", condition, test.wantReason)
+			}
+
+			if stored.Status.Readiness != clabernetesconstants.NodeStatusNotReady {
+				t.Fatalf("readiness = %q, want %q",
+					stored.Status.Readiness,
+					clabernetesconstants.NodeStatusNotReady,
+				)
+			}
+		})
 	}
 }

--- a/controllers/node/sensitivevalues.go
+++ b/controllers/node/sensitivevalues.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	"bytes"
+
+	clabernetesinternaldeviceplan "github.com/clabernetes/clabernetes/internal/deviceplan"
+)
+
+// declaredNodeText collects what a user declares in plain text for every Node of a compiled
+// planning input: the name, kind, type, and containerlab definition. All of it is readable on
+// the Node and Topology objects before any artifact is generated, so nothing in it can be a
+// secret the artifact guards need to keep out of a ConfigMap.
+func declaredNodeText(input clabernetesinternaldeviceplan.Input) [][]byte {
+	result := make([][]byte, 0, len(input.Nodes))
+
+	for _, node := range input.Nodes {
+		for _, text := range [][]byte{
+			[]byte(node.Name),
+			[]byte(node.Kind),
+			[]byte(node.Type),
+			node.Definition,
+		} {
+			if len(text) != 0 {
+				result = append(result, text)
+			}
+		}
+	}
+
+	return result
+}
+
+// screenSensitiveValues merges sensitive value sets, dropping empty values and every value that
+// already appears verbatim in the declared Node text. The artifact guards reject any plan or
+// planner input that contains a sensitive value; a value the user also wrote into a definition
+// (an SSH probe password that doubles as the device username, for example) would otherwise
+// reject every plan for that Node while protecting nothing, because the definition is stored in
+// plain text anyway. Values absent from the declared text keep their full protection.
+func screenSensitiveValues(declared [][]byte, sets ...[][]byte) [][]byte {
+	result := [][]byte{}
+
+	for _, set := range sets {
+		for _, value := range set {
+			if len(value) == 0 || declaredTextContains(declared, value) {
+				continue
+			}
+
+			result = append(result, value)
+		}
+	}
+
+	return result
+}
+
+func declaredTextContains(declared [][]byte, value []byte) bool {
+	for _, text := range declared {
+		if bytes.Contains(text, value) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/controllers/node/sensitivevalues_test.go
+++ b/controllers/node/sensitivevalues_test.go
@@ -1,0 +1,54 @@
+package node //nolint:testpackage // tests exercise the sensitive-value screening boundary
+
+import (
+	"reflect"
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/clabernetes/clabernetes/apis/v1alpha1"
+)
+
+func TestScreenSensitiveValuesDropsOnlyValuesDeclaredOnTheNode(t *testing.T) {
+	t.Parallel()
+
+	node := planInputTestNode("router", "uid-router", "arista_ceos", "registry.example/ceos:1")
+	node.Spec.Type = "spine"
+	node.Spec.StartupConfig = "hostname router\nusername admin privilege 15 secret 0 admin\n"
+
+	input, err := CompilePlanInput(PlanInputCompileRequest{
+		Primary:       node,
+		GroupMembers:  []string{node.GetName()},
+		NodesByName:   map[string]*clabernetesapisv1alpha1.Node{node.GetName(): node},
+		Compatibility: planInputTestCompatibility(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	declared := declaredNodeText(input)
+
+	got := screenSensitiveValues(
+		declared,
+		[][]byte{
+			[]byte("admin"),       // probe password restated by the startup-config
+			[]byte("router"),      // Node name
+			[]byte("arista_ceos"), // kind
+			[]byte("spine"),       // type
+			[]byte("registry.example/ceos:1"),
+		},
+		[][]byte{
+			[]byte(""),
+			[]byte("s3cr3t-probe"),
+			[]byte("registry-token"),
+			[]byte("Admin"), // case matters: only a verbatim match is public
+		},
+	)
+
+	want := [][]byte{[]byte("s3cr3t-probe"), []byte("registry-token"), []byte("Admin")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("screenSensitiveValues() = %q, want %q", got, want)
+	}
+
+	if got = screenSensitiveValues(nil, want); !reflect.DeepEqual(got, want) {
+		t.Fatalf("screenSensitiveValues() without declared text = %q, want %q", got, want)
+	}
+}

--- a/docs/concepts/node-profiles.md
+++ b/docs/concepts/node-profiles.md
@@ -74,6 +74,14 @@ this generic signal is intentionally process-level: a running network OS may sti
 services or converging protocols. Declare a `healthcheck`, define one in the image, or configure
 an explicit TCP or SSH probe when application-level readiness is required.
 
+SSH probe credentials live in a Secret that c9s creates for the Node. They are never copied into
+the plan ConfigMaps, and a plan whose text contains the password is refused. A password that also
+appears verbatim in the topology text, such as `admin` when a startup-config restates
+`username admin`, is not screened: it is already plain text on the Topology and Node objects, so
+refusing the plan would protect nothing. Use a password that appears nowhere in the topology when
+it must stay confidential. A refused plan is reported on the Node as `PlanApplied=False` with
+reason `PlanRejected` and a Warning event; the last applied workload keeps running.
+
 If a Node names a profile that does not exist, c9s does not silently fall back to global defaults.
 The Node remains unrealized until that explicit reference resolves.
 

--- a/docs/guides/lab-operations.md
+++ b/docs/guides/lab-operations.md
@@ -42,7 +42,7 @@ preparation, and connectivity conditions, the plan digest, and the applied NodeP
 | Condition | Meaning |
 | --- | --- |
 | `NodeProfileResolved` | the referenced NodeProfile exists |
-| `PlanApplied` | the current spec was planned and rendered; when `False`, the reason names the cause, for example `PlanPending`, `ImagePullSecretMissing`, `OCIMetadataResolveManifest`, or `DeploymentInvalid` |
+| `PlanApplied` | the current spec was planned and rendered; when `False`, the reason names the cause, for example `PlanPending`, `ImagePullSecretMissing`, `OCIMetadataResolveManifest`, `PlanRejected`, or `DeploymentInvalid` |
 | `Prepared` | the preparation init container staged and verified every file |
 | `ConnectivityReady` | every interface of the cold-start plan exists |
 | `ContainersReady` | every application container of the Node runs and passes its probes |


### PR DESCRIPTION
## Summary

Fixes #321.

- Sensitive values that already appear verbatim in a group member's declared text (name, kind, type, containerlab definition) are no longer screened for by the plan artifact guards. That text is plain text on the Topology and Node, so refusing generated artifacts for it protects nothing; Secret-only values keep full protection. Applies to every source: registry credentials, entropy seed, certificate material, probe passwords.
- A refused artifact is reported on the Node: `PlanApplied=False` with reason `PlanRejected` (malformed, oversized, or secret-carrying) or `PlanArtifactConflict` (foreign object at an immutable artifact name), plus a Warning event. The last applied workload is left unchanged.
- Docs: `PlanRejected` listed among the `PlanApplied` reasons; probe-credential protection and the declared-text rule explained on the NodeProfile concepts page.

## Validation

- `go test ./controllers/node/...`, `make lint`, `make check-docs`, `openspec validate --strict`: clean. `make test`: only the known host-specific `internal/deviceplan` xattr failure.
- New tests: helper unit test, condition-mapping table test, and two reconcile tests (declared password accepted and mounted; undeclared value refused with `PlanRejected` condition and event, no plan ConfigMap, no workload).
- Live on a 3-node cluster with a 2x cEOS lab (probe password `admin`, startup-config `username admin privilege 15 secret 0 admin`): stalls with no pods on the previous manager; on this build the lab reaches ready, a probe password absent from the topology text reports `PlanRejected` with a Warning event and leaves the running pods untouched, reverting restores ready within seconds, and a startup-config change rolls the workload and returns to ready.
